### PR TITLE
Improve model validation, thinking safety, and errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,13 @@ Or to use Gemini models:
 }
 ```
 
+You can also print shell exports:
+
+```bash
+eval "$(antigravity-claude-proxy env)"
+eval "$(antigravity-claude-proxy env gemini)"
+```
+
 ### Run Claude Code
 
 ```bash

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,6 +15,32 @@ const packageJson = JSON.parse(
 const args = process.argv.slice(2);
 const command = args[0];
 
+const CLAUDE_ENV = {
+  ANTHROPIC_AUTH_TOKEN: 'test',
+  ANTHROPIC_BASE_URL: 'http://localhost:8080',
+  ANTHROPIC_MODEL: 'claude-opus-4-5-thinking',
+  ANTHROPIC_DEFAULT_OPUS_MODEL: 'claude-opus-4-5-thinking',
+  ANTHROPIC_DEFAULT_SONNET_MODEL: 'claude-sonnet-4-5-thinking',
+  ANTHROPIC_DEFAULT_HAIKU_MODEL: 'claude-sonnet-4-5',
+  CLAUDE_CODE_SUBAGENT_MODEL: 'claude-sonnet-4-5-thinking'
+};
+
+const GEMINI_ENV = {
+  ANTHROPIC_AUTH_TOKEN: 'test',
+  ANTHROPIC_BASE_URL: 'http://localhost:8080',
+  ANTHROPIC_MODEL: 'gemini-3-pro-high',
+  ANTHROPIC_DEFAULT_OPUS_MODEL: 'gemini-3-pro-high',
+  ANTHROPIC_DEFAULT_SONNET_MODEL: 'gemini-3-flash',
+  ANTHROPIC_DEFAULT_HAIKU_MODEL: 'gemini-2.5-flash-lite',
+  CLAUDE_CODE_SUBAGENT_MODEL: 'gemini-3-flash'
+};
+
+function renderEnv(env) {
+  return Object.entries(env)
+    .map(([key, value]) => `export ${key}=${value}`)
+    .join('\n');
+}
+
 function showHelp() {
   console.log(`
 antigravity-claude-proxy v${packageJson.version}
@@ -26,6 +52,7 @@ USAGE:
 
 COMMANDS:
   start                 Start the proxy server (default port: 8080)
+  env                   Print export statements for Claude Code CLI
   accounts              Manage Google accounts (interactive)
   accounts add          Add a new Google account via OAuth
   accounts list         List all configured accounts
@@ -43,6 +70,8 @@ ENVIRONMENT:
 EXAMPLES:
   antigravity-claude-proxy start
   PORT=3000 antigravity-claude-proxy start
+  eval "$(antigravity-claude-proxy env)"
+  eval "$(antigravity-claude-proxy env gemini)"
   antigravity-claude-proxy accounts add
   antigravity-claude-proxy accounts list
 
@@ -58,6 +87,12 @@ CONFIGURATION:
 
 function showVersion() {
   console.log(packageJson.version);
+}
+
+function showEnv() {
+  const mode = args[1];
+  const env = mode === 'gemini' ? GEMINI_ENV : CLAUDE_ENV;
+  console.log(renderEnv(env));
 }
 
 async function main() {
@@ -78,6 +113,10 @@ async function main() {
     case undefined:
       // Default to starting the server
       await import('../src/index.js');
+      break;
+
+    case 'env':
+      showEnv();
       break;
 
     case 'accounts': {

--- a/tests/run-all.cjs
+++ b/tests/run-all.cjs
@@ -9,6 +9,7 @@ const { spawn } = require('child_process');
 const path = require('path');
 
 const tests = [
+    { name: 'Thinking Utils', file: 'test-thinking-utils.cjs' },
     { name: 'Thinking Signatures', file: 'test-thinking-signatures.cjs' },
     { name: 'Multi-turn Tools (Non-Streaming)', file: 'test-multiturn-thinking-tools.cjs' },
     { name: 'Multi-turn Tools (Streaming)', file: 'test-multiturn-thinking-tools-streaming.cjs' },

--- a/tests/test-thinking-utils.cjs
+++ b/tests/test-thinking-utils.cjs
@@ -1,0 +1,47 @@
+const assert = require('node:assert/strict');
+
+async function run() {
+    const {
+        reorderAssistantContent,
+        restoreThinkingSignatures,
+        filterUnsignedThinkingBlocks
+    } = await import('../src/format/thinking-utils.js');
+
+    const shortSignature = 'x'.repeat(10);
+    const validSignature = 'y'.repeat(60);
+
+    // reorderAssistantContent drops invalid thinking blocks
+    const reordered = reorderAssistantContent([
+        { type: 'thinking', thinking: 'secret', signature: shortSignature },
+        { type: 'text', text: 'ok' }
+    ]);
+    assert.equal(reordered.some(block => block.type === 'thinking'), false);
+    assert.equal(reordered.some(block => block.type === 'text'), true);
+
+    // restoreThinkingSignatures keeps only valid thinking blocks
+    const restored = restoreThinkingSignatures([
+        { type: 'thinking', thinking: 'secret', signature: shortSignature },
+        { type: 'thinking', thinking: 'secret2', signature: validSignature },
+        { type: 'text', text: 'ok' }
+    ]);
+    assert.equal(restored.some(block => block.type === 'thinking' && block.signature === shortSignature), false);
+    assert.equal(restored.some(block => block.type === 'thinking' && block.signature === validSignature), true);
+
+    // filterUnsignedThinkingBlocks drops invalid thought parts
+    const filtered = filterUnsignedThinkingBlocks([{
+        role: 'model',
+        parts: [
+            { thought: true, text: 'secret', thoughtSignature: shortSignature },
+            { text: 'ok' }
+        ]
+    }]);
+    assert.equal(filtered[0].parts.length, 1);
+    assert.equal(filtered[0].parts[0].text, 'ok');
+
+    console.log('Thinking utils tests passed.');
+}
+
+run().catch((error) => {
+    console.error('Thinking utils test failed:', error);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary
- validate/alias models per account and surface structured model/project errors
- clamp thinking budgets vs max_tokens, add count_tokens 501, and cache tool schemas
- add endpoint fallback controls/log throttling and a thinking-utils regression test

## Testing
- Not run (not requested)