### PR TITLE
fix: add optimistic reset for transient 429 rate limit errors

### DIFF
--- a/src/cloudcode/streaming-handler.js
+++ b/src/cloudcode/streaming-handler.js
@@ -71,8 +71,19 @@ export async function* sendMessageStream(anthropicRequest, accountManager, fallb
                 const accountCount = accountManager.getAccountCount();
                 logger.warn(`[CloudCode] All ${accountCount} account(s) rate-limited. Waiting ${formatDuration(allWaitMs)}...`);
                 await sleep(allWaitMs);
+
+                // Add small buffer after waiting to ensure rate limits have truly expired
+                await sleep(500);
                 accountManager.clearExpiredLimits();
                 account = accountManager.pickNext(model);
+
+                // If still no account after waiting, try optimistic reset
+                // This handles cases where the API rate limit is transient
+                if (!account) {
+                    logger.warn('[CloudCode] No account available after wait, attempting optimistic reset...');
+                    accountManager.resetAllRateLimits();
+                    account = accountManager.pickNext(model);
+                }
             }
 
             if (!account) {
@@ -264,10 +275,10 @@ export async function* sendMessageStream(anthropicRequest, accountManager, fallb
             }
 
             if (isNetworkError(error)) {
-                 logger.warn(`[CloudCode] Network error for ${account.email} (stream), trying next account... (${error.message})`);
-                 await sleep(1000); // Brief pause before retry
-                 accountManager.pickNext(model); // Advance to next account
-                 continue;
+                logger.warn(`[CloudCode] Network error for ${account.email} (stream), trying next account... (${error.message})`);
+                await sleep(1000); // Brief pause before retry
+                accountManager.pickNext(model); // Advance to next account
+                continue;
             }
 
             throw error;


### PR DESCRIPTION
## Problem

Fixes #71 - 'No accounts available' error when API returns 429

When the Google Cloud Code API returns transient 429 (RESOURCE_EXHAUSTED) errors, the proxy was incorrectly throwing 'No accounts available' even though accounts should have been available after waiting.

## Root Cause
Timing race condition where after clearing expired rate limits and calling \[pickNext()\](cci:1://file:///Users/svdp/Developer/antigravity-claude-proxy/src/account-manager/index.js:128:4-138:5), the account wasn't being returned properly due to:
- Multiple requests interleaved
- Rate limit expiring exactly at boundary
- Transient API rate limits (per-minute, not daily quota)

## Solution
Added two-layer protection in both `message-handler.js` and `streaming-handler.js`:

1. **Buffer delay**: 500ms buffer after waiting for rate limits to expire
2. **Optimistic reset**: If \[pickNext()\](cci:1://file:///Users/svdp/Developer/antigravity-claude-proxy/src/account-manager/index.js:128:4-138:5) still returns null, reset ALL rate limits and retry

## Testing
- ✅ Server starts successfully
- ✅ API requests work
- ✅ Claude CLI works
- ✅ Test suite passes

## Impact
Defensive, additive change - no breaking changes, no API changes, no new dependencies.