### PR TITLE
feat: fallback to alternate model when max retries exceeded with 5xx errors

### DIFF
--- a/src/cloudcode/message-handler.js
+++ b/src/cloudcode/message-handler.js
@@ -218,5 +218,15 @@ export async function sendMessage(anthropicRequest, accountManager, fallbackEnab
         }
     }
 
+    // All retries exhausted - try fallback model if enabled
+    if (fallbackEnabled) {
+        const fallbackModel = getFallbackModel(model);
+        if (fallbackModel) {
+            logger.warn(`[CloudCode] All retries exhausted for ${model}. Attempting fallback to ${fallbackModel}`);
+            const fallbackRequest = { ...anthropicRequest, model: fallbackModel };
+            return await sendMessage(fallbackRequest, accountManager, false); // Disable fallback for recursive call
+        }
+    }
+
     throw new Error('Max retries exceeded');
 }

--- a/src/cloudcode/streaming-handler.js
+++ b/src/cloudcode/streaming-handler.js
@@ -285,6 +285,17 @@ export async function* sendMessageStream(anthropicRequest, accountManager, fallb
         }
     }
 
+    // All retries exhausted - try fallback model if enabled
+    if (fallbackEnabled) {
+        const fallbackModel = getFallbackModel(model);
+        if (fallbackModel) {
+            logger.warn(`[CloudCode] All retries exhausted for ${model}. Attempting fallback to ${fallbackModel} (streaming)`);
+            const fallbackRequest = { ...anthropicRequest, model: fallbackModel };
+            yield* sendMessageStream(fallbackRequest, accountManager, false); // Disable fallback for recursive call
+            return;
+        }
+    }
+
     throw new Error('Max retries exceeded');
 }
 


### PR DESCRIPTION
## Summary

When all accounts fail with HTTP 500/503 errors (e.g., Google API returning 'Unknown Error' for Claude models on large conversations), the proxy now attempts to use a fallback model if `--fallback` is enabled.

## Problem

As documented in #88, Claude models can fail with HTTP 500 "Unknown Error" on very large conversations (99+ messages with images/documents). All accounts fail with the same error, and the proxy currently throws "Max retries exceeded" without attempting a fallback.

## Solution

Extended the existing fallback mechanism to trigger not just on rate-limit exhaustion, but also when max retries are exceeded due to 5xx errors.

### Before
```
[CloudCode] Account X failed with 5xx error, trying next...
[CloudCode] Account Y failed with 5xx error, trying next...
[ERROR] Max retries exceeded
```

### After (with --fallback enabled)
```
[CloudCode] Account X failed with 5xx error, trying next...
[CloudCode] Account Y failed with 5xx error, trying next...
[CloudCode] All retries exhausted for claude-opus-4-5-thinking. Attempting fallback to gemini-3-pro-high
[CloudCode] Stream completed
```

## Changes

- **src/cloudcode/message-handler.js**: Added fallback attempt before throwing "Max retries exceeded"
- **src/cloudcode/streaming-handler.js**: Same change for streaming requests

## Testing

- All existing tests pass (10/10)
- Syntactically verified with `node --check`
- The fallback uses the existing `MODEL_FALLBACK_MAP` configuration

## Usage

Users need to enable fallback mode:
```bash
antigravity-proxy --fallback
# or
FALLBACK=true antigravity-proxy
```

Relates to #88