### PR TITLE
fix: ensure stopReason is set correctly based on finishReason (Compatible with standard protocols)

### DIFF
--- a/src/cloudcode/sse-streamer.js
+++ b/src/cloudcode/sse-streamer.js
@@ -213,7 +213,7 @@ export async function* streamSSEResponse(response, originalModel) {
                 }
 
                 // Check finish reason
-                if (firstCandidate.finishReason) {
+                if (firstCandidate.finishReason && !stopReason) {
                     if (firstCandidate.finishReason === 'MAX_TOKENS') {
                         stopReason = 'max_tokens';
                     } else if (firstCandidate.finishReason === 'STOP') {


### PR DESCRIPTION
This pull request makes a small logic improvement to the `streamSSEResponse` function in `src/cloudcode/sse-streamer.js`. The change ensures that the finish reason is only processed if it exists and a stop reason has not already been set.

when tool_call , stopReason may be override to end_return