### PR TITLE
fix: add image response support

### DIFF
--- a/src/cloudcode/sse-parser.js
+++ b/src/cloudcode/sse-parser.js
@@ -89,6 +89,11 @@ export async function parseThinkingSSEResponse(response, originalModel) {
                         if (!part.text) continue;
                         flushThinking();
                         accumulatedText += part.text;
+                    } else if (part.inlineData) {
+                        // Handle image content
+                        flushThinking();
+                        flushText();
+                        finalParts.push(part);
                     }
                 }
             } catch (e) {
@@ -105,7 +110,7 @@ export async function parseThinkingSSEResponse(response, originalModel) {
         usageMetadata
     };
 
-    const partTypes = finalParts.map(p => p.thought ? 'thought' : (p.functionCall ? 'functionCall' : 'text'));
+    const partTypes = finalParts.map(p => p.thought ? 'thought' : (p.functionCall ? 'functionCall' : (p.inlineData ? 'inlineData' : 'text')));
     logger.debug('[CloudCode] Response received (SSE), part types:', partTypes);
     if (finalParts.some(p => p.thought)) {
         const thinkingPart = finalParts.find(p => p.thought);

--- a/src/format/response-converter.js
+++ b/src/format/response-converter.js
@@ -71,6 +71,16 @@ export function convertGoogleToAnthropic(googleResponse, model) {
 
             anthropicContent.push(toolUseBlock);
             hasToolCalls = true;
+        } else if (part.inlineData) {
+            // Handle image content from Google format
+            anthropicContent.push({
+                type: 'image',
+                source: {
+                    type: 'base64',
+                    media_type: part.inlineData.mimeType,
+                    data: part.inlineData.data
+                }
+            });
         }
     }
 


### PR DESCRIPTION
## Summary

Add `inlineData` handling to properly convert Google's image format to Anthropic's `type: 'image'` format. This fixes the issue where images generated by models like `gemini-3-pro-image` were not being returned to clients.

## Changes

- `src/format/response-converter.js`: Convert `inlineData` to Anthropic image format in non-streaming responses
- `src/cloudcode/sse-streamer.js`: Stream image blocks in real-time
- `src/cloudcode/sse-parser.js`: Parse `inlineData` for thinking models

## Test plan
- [x] Tested image generation with `gemini-3-pro-image` model - images now return correctly

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)