### PR TITLE
feat: add API key authentication for public deployment security

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ While most users can use the default settings, you can tune the proxy behavior v
 
 ### Configurable Options
 
+- **API Key Authentication**: Protect `/v1/*` API endpoints with `API_KEY` env var or `apiKey` in config.
 - **WebUI Password**: Secure your dashboard with `WEBUI_PASSWORD` env var or in config.
 - **Custom Port**: Change the default `8080` port.
 - **Retry Logic**: Configure `maxRetries`, `retryBaseMs`, and `retryMaxMs`.

--- a/config.example.json
+++ b/config.example.json
@@ -11,6 +11,9 @@
     "Restart server after making changes"
   ],
 
+  "apiKey": "",
+  "_apiKey_comment": "Optional API key to protect /v1/* endpoints. Can also use API_KEY env var.",
+
   "webuiPassword": "",
   "_webuiPassword_comment": "Optional password to protect WebUI. Can also use WEBUI_PASSWORD env var.",
 

--- a/src/config.js
+++ b/src/config.js
@@ -5,6 +5,7 @@ import { logger } from './utils/logger.js';
 
 // Default config
 const DEFAULT_CONFIG = {
+    apiKey: '',
     webuiPassword: '',
     debug: false,
     logLevel: 'info',
@@ -54,6 +55,7 @@ function loadConfig() {
         }
 
         // Environment overrides
+        if (process.env.API_KEY) config.apiKey = process.env.API_KEY;
         if (process.env.WEBUI_PASSWORD) config.webuiPassword = process.env.WEBUI_PASSWORD;
         if (process.env.DEBUG === 'true') config.debug = true;
 


### PR DESCRIPTION
Add optional API key authentication for `/v1/*` endpoints to enhance security when deploying the proxy on public networks.
