### PR TITLE
fix: resolve save preset modal scope issue in Claude config

### DIFF
--- a/public/js/components/claude-config.js
+++ b/public/js/components/claude-config.js
@@ -18,6 +18,7 @@ window.Components.claudeConfig = () => ({
     savingPreset: false,
     deletingPreset: false,
     pendingPresetName: '', // For unsaved changes confirmation
+    newPresetName: '', // For save preset modal input
 
     // Model fields that may contain Gemini model names
     geminiModelFields: [
@@ -307,7 +308,8 @@ window.Components.claudeConfig = () => ({
      * Save the current config as a new preset
      */
     async saveCurrentAsPreset() {
-        // Show the save preset modal
+        // Clear the input and show the save preset modal
+        this.newPresetName = '';
         document.getElementById('save_preset_modal').showModal();
     },
 
@@ -354,6 +356,7 @@ window.Components.claudeConfig = () => ({
             if (data.status === 'ok') {
                 this.presets = data.presets || [];
                 this.selectedPresetName = name.trim();
+                this.newPresetName = ''; // Clear the input
                 Alpine.store('global').showToast(
                     Alpine.store('global').t('presetSaved') || `Preset "${name}" saved`,
                     'success'

--- a/public/views/settings.html
+++ b/public/views/settings.html
@@ -645,7 +645,7 @@
                 </dialog>
 
                 <!-- Save Preset Modal -->
-                <dialog id="save_preset_modal" class="modal" x-data="{ presetName: '' }">
+                <dialog id="save_preset_modal" class="modal">
                     <div class="modal-box bg-space-900 border-2 border-neon-cyan/50">
                         <h3 class="font-bold text-lg text-neon-cyan flex items-center gap-2">
                             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -660,26 +660,26 @@
                             <label class="label">
                                 <span class="label-text text-gray-300" x-text="$store.global.t('presetName') || 'Preset Name'">Preset Name</span>
                             </label>
-                            <input type="text" x-model="presetName"
+                            <input type="text" x-model="newPresetName"
                                 class="input input-sm input-bordered bg-space-800 border-space-border text-white w-full"
                                 :placeholder="$store.global.t('presetNamePlaceholder') || 'e.g., My Work Setup'"
-                                @keydown.enter="$root.executeSavePreset(presetName); presetName = ''"
-                                x-init="$watch('$el.closest(\'dialog\').open', open => { if (open) { presetName = ''; $nextTick(() => $el.focus()) } })"
+                                @keydown.enter="executeSavePreset(newPresetName)"
+                                x-init="$watch('$el.closest(\'dialog\').open', open => { if (open) { $nextTick(() => $el.focus()) } })"
                                 aria-label="Preset name">
                         </div>
                         <div class="modal-action">
-                            <button class="btn btn-ghost text-gray-400" @click="presetName = ''; document.getElementById('save_preset_modal').close()"
+                            <button class="btn btn-ghost text-gray-400" @click="newPresetName = ''; document.getElementById('save_preset_modal').close()"
                                 x-text="$store.global.t('cancel')">Cancel</button>
                             <button class="btn bg-neon-cyan hover:bg-cyan-600 border-none text-black"
-                                @click="$root.executeSavePreset(presetName); presetName = ''"
-                                :disabled="!presetName.trim() || $root.savingPreset"
-                                :class="{ 'loading': $root.savingPreset }">
-                                <span x-show="!$root.savingPreset" x-text="$store.global.t('savePreset') || 'Save Preset'">Save Preset</span>
+                                @click="executeSavePreset(newPresetName)"
+                                :disabled="!newPresetName.trim() || savingPreset"
+                                :class="{ 'loading': savingPreset }">
+                                <span x-show="!savingPreset" x-text="$store.global.t('savePreset') || 'Save Preset'">Save Preset</span>
                             </button>
                         </div>
                     </div>
                     <form method="dialog" class="modal-backdrop">
-                        <button @click="presetName = ''">close</button>
+                        <button @click="newPresetName = ''">close</button>
                     </form>
                 </dialog>
             </div>


### PR DESCRIPTION
## Summary
Fixed a bug where the "Save" button in the "Save as Preset" modal would remain disabled or not function correctly due to an Alpine.js scope issue. The modal had its own `x-data` scope, which prevented access to the parent component's properties (referenced via `$root` which was pointing to the modal scope instead of the component).

## Changes
- Removed nested `x-data="{ presetName: '' }"` from the save preset dialog to allow inheritance of the parent `claudeConfig` scope.
- Added `newPresetName` to the parent `claudeConfig` component state.
- Updated the input and button to use `newPresetName` and `savingPreset` directly.
- Added logic to focus the input field when the modal opens.
- Cleared the input field after a successful save.

## Testing
- Verified that the "Save" button now correctly enables when text is entered.
- Verified that saving works and the loading state is displayed.
- Verified that the modal closes and input clears after saving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)