### PR TITLE
docs: update startup message to mention WebUI

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ app.listen(PORT, () => {
 ║           Antigravity Claude Proxy Server                    ║
 ╠══════════════════════════════════════════════════════════════╣
 ║                                                              ║
-${border}  ${align(`Server running at: http://localhost:${PORT}`)}${border}
+${border}  ${align(`Server and WebUI running at: http://localhost:${PORT}`)}${border}
 ${statusSection}║                                                              ║
 ${controlSection}
 ║                                                              ║


### PR DESCRIPTION
## Summary
- Updated server startup banner to explicitly mention the WebUI
- Changed message from "Server running at" to "Server and WebUI running at"

## Details
Previously, the startup message only mentioned the server, which could be confusing since the WebUI is available at the same endpoint. This change clarifies that both the API server and the web management interface are running on the configured port.

**Before:**
Server running at: http://localhost:8080

**After:**
Server and WebUI running at: http://localhost:8080

## Testing
- Start the server with `npm start`
- Verify the startup banner displays the updated message