### PR TITLE
docs: add macOS menu bar app section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ Refer to `config.example.json` for a complete list of fields and documentation.
 
 For macOS users who prefer a native experience, there's a companion menu bar app that provides quick access to server controls without touching the terminal. Get it from: [antigravity-claude-proxy-bar](https://github.com/IrvanFza/antigravity-claude-proxy-bar)
 
+> **Note:** This is a GUI wrapper only. You still need to install and setup the proxy server first using one of the [installation methods](#installation) above.
+
 ![AntiGravity Claude Proxy Bar](https://github.com/IrvanFza/antigravity-claude-proxy-bar/blob/main/images/application.png?raw=true)
 
 ### Key Features


### PR DESCRIPTION
## Summary
- Add documentation for the companion macOS menu bar app ([antigravity-claude-proxy-bar](https://github.com/IrvanFza/antigravity-claude-proxy-bar))
- Include screenshot and key features highlighting native server controls, status indicator, and auto-start options

## Test plan
- [x] Verify the screenshot renders correctly in the README
- [x] Confirm the external repository link works

## App Screenshot
![AntiGravity Claude Proxy Bar](https://github.com/IrvanFza/antigravity-claude-proxy-bar/blob/main/images/application.png?raw=true)
