### PR TITLE
fix: Escape OAuth URL parameters for Windows CLI

### DIFF
--- a/src/cli/accounts.js
+++ b/src/cli/accounts.js
@@ -95,7 +95,7 @@ function openBrowser(url) {
         args = [url];
     } else if (platform === 'win32') {
         command = 'cmd';
-        args = ['/c', 'start', '', url];
+        args = ['/c', 'start', '', url.replace(/&/g, '^&')];
     } else {
         command = 'xdg-open';
         args = [url];


### PR DESCRIPTION
<h2>Summary</h2>
This PR addresses a critical bug in the CLI authentication flow on Windows environments where the OAuth authorization URL was being truncated by the command prompt, causing "missing parameter: response_type" errors during sign-in.

<h2>Key Changes</h2>

Windows CLI URL Escaping (src/cli/accounts.js)
Added logic to correctly escape ampersand characters (& -> ^&) when spawning the browser via cmd /c start on Windows.
This ensures the command processor passes the complete query string (including response_type and other parameters) to the browser instead of interpreting the & as a command separator.
<h2>Impact</h2>

Usability: Windows users can now successfully run npm run accounts and complete the authentication flow without manual URL copying.
Cross-Platform Compatibility: The fix is strictly applied only when process.platform === 'win32', ensuring no regressions for macOS or Linux users.