### PR TITLE
fix(security): redact sensitive config values and harden WebUI configuration API

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -93,7 +93,14 @@ function loadConfig() {
 loadConfig();
 
 export function getPublicConfig() {
-    return { ...config };
+    // Create a deep copy and redact sensitive fields
+    const publicConfig = JSON.parse(JSON.stringify(config));
+
+    // Redact sensitive values
+    if (publicConfig.webuiPassword) publicConfig.webuiPassword = '********';
+    if (publicConfig.apiKey) publicConfig.apiKey = '********';
+
+    return publicConfig;
 }
 
 export function saveConfig(updates) {

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -127,8 +127,9 @@ function createAuthMiddleware() {
 
         // Determine if this path should be protected
         const isApiRoute = req.path.startsWith('/api/');
-        const isException = req.path === '/api/auth/url' || req.path === '/api/config';
-        const isProtected = (isApiRoute && !isException) || req.path === '/account-limits' || req.path === '/health';
+        const isAuthUrl = req.path === '/api/auth/url';
+        const isConfigGet = req.path === '/api/config' && req.method === 'GET';
+        const isProtected = (isApiRoute && !isAuthUrl && !isConfigGet) || req.path === '/account-limits' || req.path === '/health';
 
         if (isProtected) {
             const providedPassword = req.headers['x-webui-password'] || req.query.password;


### PR DESCRIPTION
### **Description**
This PR addresses a security vulnerability where sensitive server credentials (`webuiPassword` and `apiKey`) were exposed in plain text via the public `/api/config` endpoint. 

**Closes #179**

### **Key Changes**
1.  **Sensitive Data Redaction (`src/config.js`)**:
    *   Updated `getPublicConfig()` to return a deep-cloned copy of the configuration.
    *   Replaced `webuiPassword` and `apiKey` values with a mask (`********`) before serving them to the client.
    *   Ensured redaction only affects the API response without modifying active credentials in memory.

2.  **Endpoint Protection Hardening (`src/webui/index.js`)**:
    *   Refined `AuthMiddleware` to distinguish between "Read" and "Write" operations.
    *   `GET /api/config` remains accessible (serving redacted data) for UI initialization.
    *   `POST /api/config` and other configuration updates now **strictly require** `x-webui-password` authentication.

### **Why this is necessary**
Exposing administrative passwords in plain text, even in local deployments, poses risks from:
- **CSRF Attacks**: Malicious sites could script requests to `localhost` to steal passwords or disable accounts.
- **LAN Discovery**: Network users could scan the proxy port and gain full control over the account pool.
- **Deployment Security**: Protects credentials for users running the proxy on NAS, Routers, or VPS environments.

### **Testing performed**
- [x] Verified `GET /api/config` masks password as `********`.
- [x] Verified `POST /api/config` returns `401 Unauthorized` without correct credentials.
- [x] Confirmed WebUI remains fully functional.
