### PR TITLE
Bump version to 2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity-claude-proxy",
-  "version": "1.2.6",
+  "version": "2.4.1",
   "description": "Proxy server to use Antigravity's Claude models with Claude Code CLI",
   "main": "src/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump version from 1.2.6 to 2.4.1 to sync with latest release

## Test plan
- [ ] Verify package.json shows correct version