### PR TITLE
Bug: Disabled accounts affect Global Quota and appear in Account Distribution

### DIFF
--- a/public/js/data-store.js
+++ b/public/js/data-store.js
@@ -237,6 +237,7 @@ document.addEventListener('alpine:init', () => {
                 let minResetTime = null;
 
                 this.accounts.forEach(acc => {
+                    if (acc.enabled === false) return;
                     if (this.filters.account !== 'all' && acc.email !== this.filters.account) return;
 
                     const limit = acc.limits?.[modelId];
@@ -352,6 +353,7 @@ document.addEventListener('alpine:init', () => {
                 const quotaInfo = [];
                 // Use ALL accounts (no account filter)
                 this.accounts.forEach(acc => {
+                    if (acc.enabled === false) return;
                     const limit = acc.limits?.[modelId];
                     if (!limit) return;
                     const pct = limit.remainingFraction !== null ? Math.round(limit.remainingFraction * 100) : 0;


### PR DESCRIPTION
## Description
Disabled accounts are currently included in the "Account Distribution" view and the "Global Quota" average calculation on the Models page.

This causes the global average to be skewed and inaccurate. For example, a disabled account with full quota (100%) artificially inflates the average, while one with no quota drags it down. In either case, the metric fails to represent the true capacity of the active account pool. Additionally, these accounts clutter the interface with irrelevant data.

## Steps to Reproduce
 1. Go to the Accounts page and disable an account.
 2. Navigate to the Models page.
 3. Expand a model to view "Account Distribution".
 4. Observe that the disabled account is still listed.
 5. Check the "Global Quota" percentage; it includes the disabled account's quota.

## Expected Behavior
 - Disabled accounts should be excluded from the "Account Distribution" list.
 - Disabled accounts should not contribute to the "Global Quota" average calculation.
 - The Dashboard quota distribution chart should only reflect enabled accounts.

## Affected Files
 - `public/js/data-store.js`

## Solution
Update `computeQuotaRows()` and `getUnfilteredQuotaData()` in `public/js/data-store.js` to filter out accounts where `enabled === false` before processing statistics.