### PR TITLE
fix: resolve Alpine.js syntax errors and missing modelManager

### DIFF
--- a/public/js/components/models.js
+++ b/public/js/components/models.js
@@ -34,3 +34,27 @@ window.Components.models = () => ({
         return window.ModelConfigUtils.updateModelConfig(modelId, configUpdates);
     }
 });
+
+/**
+ * Model Manager Component (Settings Tab)
+ * Handles model mapping and configuration editing
+ */
+window.Components.modelManager = () => ({
+    editingId: null,
+
+    isEditing(modelId) {
+        return this.editingId === modelId;
+    },
+
+    startEditing(modelId) {
+        this.editingId = modelId;
+    },
+
+    stopEditing() {
+        this.editingId = null;
+    },
+
+    async updateModelConfig(modelId, configUpdates) {
+        return window.ModelConfigUtils.updateModelConfig(modelId, configUpdates);
+    }
+});

--- a/public/views/settings.html
+++ b/public/views/settings.html
@@ -243,7 +243,7 @@
                             <span x-show="deletingPreset" class="loading loading-spinner loading-xs"></span>
                         </button>
                     </div>
-                    <p class="text-[10px] text-gray-600 mt-2" x-text="$store.global.t('presetHint') || 'Select a preset to load it. Click \"Apply to Claude CLI\" to save changes.'">Select a preset to load it. Click "Apply to Claude CLI" to save changes.</p>
+                    <p class="text-[10px] text-gray-600 mt-2" x-text="$store.global.t('presetHint') || 'Select a preset to load it. Click &quot;Apply to Claude CLI&quot; to save changes.'">Select a preset to load it. Click "Apply to Claude CLI" to save changes.</p>
                 </div>
 
                 <!-- Base URL -->
@@ -625,7 +625,7 @@
                         <p class="py-4 text-gray-300">
                             <span x-text="$store.global.t('unsavedChangesMessage') || 'Your current configuration doesn\'t match any saved preset.'">Your current configuration doesn't match any saved preset.</span>
                             <br><br>
-                            <span class="text-yellow-400/80" x-text="'Load \"' + pendingPresetName + '\" and lose current changes?'"></span>
+                            <span class="text-yellow-400/80" x-text="'Load &quot;' + pendingPresetName + '&quot; and lose current changes?'"></span>
                         </p>
                         <div class="modal-action">
                             <button class="btn btn-ghost text-gray-400" @click="cancelLoadPreset()"


### PR DESCRIPTION
## Summary
This PR resolves two UI issues reported in the browser console:
1. **Missing Component**: The `modelManager` component (used for editing model mappings) was referenced in HTML but missing in the JavaScript. It has been added to `public/js/components/models.js`.
2. **Syntax Errors**: Fixed `Invalid or unexpected token` errors in `settings.html` caused by using escaped quotes (`\"`) inside HTML attributes. These were replaced with HTML entities (`&quot;`) to ensure cross-browser compatibility.

## Changes
- `public/js/components/models.js`: Added `window.Components.modelManager` definition.
- `public/views/settings.html`: Fixed quoting in `x-text` directives for preset hints and unsaved changes modal.