### PR TITLE
docs: add Clawdbot/Moltbot integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,93 @@ Then run `claude` for official API or `claude-antigravity` for this proxy.
 
 ---
 
+## Using with Clawdbot / Moltbot
+
+[Clawdbot/Moltbot](https://docs.molt.bot/) is an AI agent platform that can connect to messaging apps like Telegram, WhatsApp, Discord, and more. You can configure it to use this proxy for Claude models.
+
+### Configure Clawdbot
+
+Edit your Clawdbot config file at `~/.clawdbot/clawdbot.json` (macOS/Linux) or `%USERPROFILE%\.clawdbot\clawdbot.json` (Windows):
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "antigravity-proxy/claude-opus-4-5-thinking"
+      },
+      "models": {
+        "antigravity-proxy/claude-opus-4-5-thinking": {}
+      }
+    }
+  },
+  "models": {
+    "mode": "merge",
+    "providers": {
+      "antigravity-proxy": {
+        "baseUrl": "http://localhost:8080",
+        "apiKey": "test",
+        "api": "anthropic-messages",
+        "models": [
+          {
+            "id": "claude-opus-4-5-thinking",
+            "name": "Claude Opus 4.5 Thinking",
+            "contextWindow": 200000,
+            "maxTokens": 32000
+          },
+          {
+            "id": "claude-sonnet-4-5-thinking",
+            "name": "Claude Sonnet 4.5 Thinking",
+            "contextWindow": 200000,
+            "maxTokens": 32000
+          },
+          {
+            "id": "claude-sonnet-4-5",
+            "name": "Claude Sonnet 4.5",
+            "contextWindow": 200000,
+            "maxTokens": 32000
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+### Start Both Services
+
+```bash
+# Terminal 1: Start the proxy
+antigravity-claude-proxy start
+
+# Terminal 2: Start Clawdbot gateway
+clawdbot gateway
+```
+
+### Verify Configuration
+
+```bash
+# Check available models
+clawdbot models list
+
+# Check status
+clawdbot status
+```
+
+You should see `antigravity-proxy/claude-opus-4-5-thinking` as the configured model.
+
+### Switch Models
+
+To use a different model:
+
+```bash
+clawdbot models set antigravity-proxy/claude-sonnet-4-5-thinking
+```
+
+> **Note:** Make sure the proxy is running before starting Clawdbot. The proxy must be accessible at `http://localhost:8080` (or your configured port).
+
+---
+
 ## Available Models
 
 ### Claude Models


### PR DESCRIPTION
## Summary

- Add documentation for using the antigravity-claude-proxy with **Clawdbot/Moltbot**
- Clawdbot is an AI agent platform that connects to messaging apps (Telegram, WhatsApp, Discord, Slack, etc.)
- This allows users to interact with Claude models through their favorite messaging apps via this proxy

## Changes

The guide includes:
- Configuration for custom provider in `clawdbot.json`
- Model definitions with context window and max tokens
- Commands to start both services together
- Verification steps and model switching instructions

## Use Case

Users who want to:
1. Use Claude models on messaging platforms (Telegram, WhatsApp, etc.)
2. Leverage multi-account load balancing from this proxy
3. Avoid direct Anthropic API costs by using Antigravity Cloud Code

## Test Plan

- [x] Tested configuration on Windows with Clawdbot 2026.1.24-3
- [x] Verified model listing works with custom provider
- [x] Confirmed gateway connects to proxy successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)