### PR TITLE
Fix: Return correct HTTP error codes for immediate streaming failures

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -785,11 +785,6 @@ app.post('/v1/messages', async (req, res) => {
 
         if (stream) {
             // Handle streaming response
-            res.setHeader('Content-Type', 'text/event-stream');
-            res.setHeader('Cache-Control', 'no-cache');
-            res.setHeader('Connection', 'keep-alive');
-            res.setHeader('X-Accel-Buffering', 'no');
-
             // Do NOT flush headers immediately. We need to wait for the first chunk
             // to ensure we don't send a 200 OK if the upstream fails immediately (e.g. 429/503).
 


### PR DESCRIPTION
## Description
Refactors the streaming response logic in `/v1/messages` to delay flushing HTTP headers until the first event is successfully retrieved from the stream generator.

## Problem
Previously, the server called `res.flushHeaders()` immediately upon receiving a streaming request. This forced a **200 OK** status code to be sent to the client (e.g., LiteLLM) before ensuring the upstream request was successful.

If the upstream provider returned a critical error—such as `429 Quota Exhausted` or `401 Unauthorized`—this error was wrapped inside the "successful" 200 OK stream as an SSE event. As a result, client-side fallback mechanisms failed to trigger because they interpreted the initial 200 OK as a success.

## Solution
*   **Buffer First Chunk**: The server now attempts to pull the first event from the [sendMessageStream](cci:1://file:///Users/tamnt/Projects/llm-proxies/antigravity-claude-proxy/src/cloudcode/streaming-handler.js:165:0-568:1) generator **before** sending response headers.
*   **Handle Initial Errors**: If the first pull throws an error (e.g., rate limit, auth failure), the server catches it and returns the correct HTTP status code (401, 429, 503) with a standard JSON error response.
*   **Stream Continuation**: If the first chunk is successful, the 200 OK headers are flushed, the initial chunk is written, and the rest of the stream proceeds normally.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Verification
*   Verified that immediate upstream errors now result in the correct HTTP error status code (preventing the 200 OK).
*   Verified that standard successful streams continue to function without latency penalties beyond the first chunk wait.