### PR TITLE
docs: add account selection strategy to menu bar app features

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ For macOS users who prefer a native experience, there's a companion menu bar app
 - **Status Indicator**: Menu bar icon shows server running state at a glance.
 - **WebUI Access**: Open the web management console directly from the menu.
 - **Port Configuration**: Customize the proxy server port (default: 8080).
+- **Account Selection Strategy**: Choose between Hybrid, Sticky, or Round-Robin load balancing strategies.
 - **Auto-Start Options**: Launch server on app start and launch app at login.
 - **Native Experience**: Clean, native SwiftUI interface designed for macOS.
 


### PR DESCRIPTION
## Summary
Update the macOS Menu Bar App section to include the new account selection strategy feature that was added in v1.1.0 of the menu bar app.

## Changes
- Added "Account Selection Strategy" to the Key Features list
- Users can now choose between Hybrid, Sticky, or Round-Robin load balancing strategies directly from the menu bar app

## Related
- Menu bar app release: https://github.com/IrvanFza/antigravity-claude-proxy-bar/releases/tag/v1.1.0

<img width="562" height="794" alt="image" src="https://github.com/user-attachments/assets/813fdb19-8ae1-4334-b5c1-76d270e80f2d" />