### PR TITLE
Fix: Update Antigravity version to 1.15.8 to resolve Claude Code compatibility

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -33,7 +33,7 @@ function getAntigravityDbPath() {
 function getPlatformUserAgent() {
     const os = platform();
     const architecture = arch();
-    return `antigravity/1.11.5 ${os}/${architecture}`;
+    return `antigravity/1.15.8 ${os}/${architecture}`;
 }
 
 // Cloud Code API endpoints (in fallback order)


### PR DESCRIPTION
## Problem
Claude Code now displays the following error when using the proxy as a custom endpoint:

> ⏺ This version of Antigravity is no longer supported. Please update to receive the latest features!

This prevents Claude Code from connecting to the proxy entirely.

## Root Cause
The proxy was sending `antigravity/1.11.5` in the User-Agent header (line 36 of `src/constants.js`). Claude Code now performs a version check and requires Antigravity version 1.15.8 or newer.

## Solution
Updated the User-Agent version string from `1.11.5` to `1.15.8` (latest stable release as of January 24, 2026).

## Changes
- Updated `getPlatformUserAgent()` in `src/constants.js` to return `antigravity/1.15.8`

## Testing
- ✅ Proxy starts successfully
- ✅ Claude Code connects without version errors
- ✅ API requests work normally
- ✅ No breaking changes to existing functionality

## Additional Notes
This version should be updated periodically when Antigravity releases major updates. Latest versions can be tracked at: https://antigravity.google/changelog