### PR TITLE
fix: rotate to next account on 403 VALIDATION_REQUIRED error

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -191,8 +191,12 @@ export function isAuthError(error) {
     if (error instanceof AuthError) return true;
     const msg = (error.message || '').toUpperCase();
     return msg.includes('AUTH_INVALID') ||
+        msg.includes('AUTH_VALIDATION_REQUIRED') ||
         msg.includes('INVALID_GRANT') ||
-        msg.includes('TOKEN REFRESH FAILED');
+        msg.includes('TOKEN REFRESH FAILED') ||
+        // 403 PERMISSION_DENIED with VALIDATION_REQUIRED means account needs re-verification
+        // This should trigger account rotation, not endpoint cycling
+        (msg.includes('PERMISSION_DENIED') && msg.includes('VALIDATION_REQUIRED'));
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fix 403 PERMISSION_DENIED with VALIDATION_REQUIRED not triggering account rotation
- Accounts requiring Google re-verification are now marked invalid and skipped
- Proxy continues working by switching to next available account instead of stopping

## Problem

When an account receives a `403 PERMISSION_DENIED` error with reason `VALIDATION_REQUIRED`, the proxy would:
1. Cycle through different endpoints (which all fail - it's an account issue, not endpoint)
2. Return 403 to the client
3. Stop working entirely

This is critical for users with large account pools (10-40+ accounts) who expect seamless failover.

## Solution

1. **`src/errors.js`**: Added `VALIDATION_REQUIRED` detection to `isAuthError()` function
2. **`src/cloudcode/message-handler.js`**: Handle 403 VALIDATION_REQUIRED before endpoint cycling - mark account invalid and throw to trigger rotation
3. **`src/cloudcode/streaming-handler.js`**: Same fix for streaming requests

## Before vs After

```
BEFORE:
403 VALIDATION_REQUIRED → Try endpoints → All fail → Error to client → STOPS

AFTER:
403 VALIDATION_REQUIRED → Mark account invalid → Log which account → Try next → CONTINUES
```

## Log Output (Tested)

```
[CloudCode] Account user@gmail.com needs Google re-verification (VALIDATION_REQUIRED), marking invalid and switching...
[CloudCode] Account user@gmail.com has invalid credentials, trying next...
```

## Test Plan

- [x] Tested with real 403 VALIDATION_REQUIRED error
- [x] Verified account gets marked invalid in WebUI
- [x] Verified proxy continues with next account
- [x] Works for both streaming and non-streaming requests

## Related Issues

- Fixes #246 (403 VALIDATION_REQUIRED handling)
- Addresses user reports of proxy stopping instead of failing over