### PR TITLE
fix: prevent accounts.json corruption + detect ToS-banned accounts

### DIFF
--- a/public/views/accounts.html
+++ b/public/views/accounts.html
@@ -190,12 +190,18 @@
                                 <div class="w-2 h-2 rounded-full flex-shrink-0"
                                      :class="acc.status === 'ok' ?
                                              'bg-neon-green shadow-[0_0_8px_rgba(34,197,94,0.6)] animate-pulse' :
-                                             'bg-red-500 shadow-[0_0_8px_rgba(239,68,68,0.6)]'">
+                                             (acc.status === 'banned' ? 
+                                              'bg-red-800 shadow-[0_0_8px_rgba(153,27,27,0.6)]' :
+                                              'bg-red-500 shadow-[0_0_8px_rgba(239,68,68,0.6)]')">
                                 </div>
                                 <span class="text-xs font-mono font-semibold"
-                                      :class="acc.status === 'ok' ? 'text-neon-green' : 'text-red-400'"
+                                      :class="acc.status === 'ok' ? 'text-neon-green' : (acc.status === 'banned' ? 'text-red-800' : 'text-red-400')"
                                       x-text="acc.status.toUpperCase()">
                                 </span>
+                                <p x-show="acc.status === 'banned'" 
+                                   class="text-[9px] text-red-600/70 mt-0.5 max-w-[200px] leading-tight"
+                                   x-text="acc.error || 'Gemini disabled for ToS violation'">
+                                </p>
                             </div>
                         </td>
                         <td class="py-4 pr-6">
@@ -207,6 +213,13 @@
                                     x-text="$store.global.t('fix')">
                                     FIX
                                 </button>
+                                <!-- Appeal Button (banned accounts only) -->
+                                <a x-show="acc.status === 'banned'"
+                                   href="mailto:gemini-code-assist-user-feedback@google.com"
+                                   class="px-3 py-1 text-[10px] font-bold font-mono uppercase tracking-wider rounded bg-red-900/20 text-red-400 hover:bg-red-900/30 border border-red-800/30 hover:border-red-800/50 transition-all"
+                                   title="Email Google to appeal this ban">
+                                   APPEAL
+                                </a>
                                 <!-- Settings Button (threshold) -->
                                 <button class="p-2 rounded hover:bg-white/10 text-gray-500 hover:text-neon-yellow transition-colors"
                                     @click="openThresholdModal(acc)"

--- a/src/cloudcode/model-api.js
+++ b/src/cloudcode/model-api.js
@@ -96,6 +96,13 @@ export async function fetchAvailableModels(token, projectId = null) {
             if (!response.ok) {
                 const errorText = await response.text();
                 logger.warn(`[CloudCode] fetchAvailableModels error at ${endpoint}: ${response.status}`);
+                // Detect permanent ToS ban — no point trying other endpoints
+                if (response.status === 403) {
+                    const lower = (errorText || '').toLowerCase();
+                    if (lower.includes('has been disabled') && lower.includes('violation of terms of service')) {
+                        throw new Error(`ACCOUNT_BANNED: ${errorText}`);
+                    }
+                }
                 continue;
             }
 
@@ -191,7 +198,15 @@ export async function getSubscriptionTier(token) {
             });
 
             if (!response.ok) {
+                const errorText = await response.text().catch(() => '');
                 logger.warn(`[CloudCode] loadCodeAssist error at ${endpoint}: ${response.status}`);
+                // Detect permanent ToS ban — no point trying other endpoints
+                if (response.status === 403) {
+                    const lower = (errorText || '').toLowerCase();
+                    if (lower.includes('has been disabled') && lower.includes('violation of terms of service')) {
+                        throw new Error(`ACCOUNT_BANNED: ${errorText}`);
+                    }
+                }
                 continue;
             }
 

--- a/src/cloudcode/rate-limit-state.js
+++ b/src/cloudcode/rate-limit-state.js
@@ -140,6 +140,18 @@ export function extractVerificationUrl(errorText) {
 }
 
 /**
+ * Detect if 403 error is due to a permanent account ban (ToS violation).
+ * These accounts are permanently disabled by Google and cannot be recovered
+ * by retrying or re-authenticating. User must contact Google support to appeal.
+ * @param {string} errorText - Error message from API
+ * @returns {boolean} True if account is permanently banned
+ */
+export function isAccountBanned(errorText) {
+    const lower = (errorText || '').toLowerCase();
+    return lower.includes('has been disabled') && lower.includes('violation of terms of service');
+}
+
+/**
  * Detect if 429 error is due to model capacity (not user quota).
  * Capacity issues should retry on same account with shorter delay.
  * @param {string} errorText - Error message from API

--- a/src/cloudcode/streaming-handler.js
+++ b/src/cloudcode/streaming-handler.js
@@ -32,6 +32,7 @@ import {
     isModelCapacityExhausted,
     isValidationRequired,
     extractVerificationUrl,
+    isAccountBanned,
     calculateSmartBackoff
 } from './rate-limit-state.js';
 import crypto from 'crypto';
@@ -287,6 +288,14 @@ export async function* sendMessageStream(anthropicRequest, accountManager, fallb
                             const verifyUrl = extractVerificationUrl(errorText);
                             logger.warn(`[CloudCode] 403 VALIDATION_REQUIRED/PERMISSION_DENIED for ${account.email}, marking invalid and rotating account...`);
                             accountManager.markInvalid(account.email, 'Account requires verification', verifyUrl);
+                            throw new AccountForbiddenError(errorText, account.email);
+                        }
+
+                        // 403 with permanent ToS ban — account is permanently disabled by Google
+                        // Unlike VALIDATION_REQUIRED, this cannot be resolved by verification
+                        if (response.status === 403 && isAccountBanned(errorText)) {
+                            logger.warn(`[CloudCode] 403 ToS BANNED for ${account.email}, marking invalid permanently...`);
+                            accountManager.markInvalid(account.email, 'Account banned — Gemini disabled for Terms of Service violation');
                             throw new AccountForbiddenError(errorText, account.email);
                         }
 


### PR DESCRIPTION
## Summary

Two independent fixes for production reliability issues discovered while running 15+ accounts.

### 1. Storage Protection — Prevent `accounts.json` corruption

**Problem:** When multiple async operations (rate-limit updates, quota refreshes, account additions) call `saveToDisk()` concurrently, interleaved writes corrupt `accounts.json` — truncating JSON or mixing data. This wipes all account configurations and requires manually re-adding accounts via the WebUI.

**Fix (3 layers of protection in `storage.js`):**
- **Write lock:** Promise-based serialization ensures writes are sequential
- **JSON validation:** `JSON.parse(json)` check before writing catches serialization bugs
- **Atomic write:** Write to `.tmp` file then `rename()` — prevents partial writes on crash

### 2. ToS Ban Detection — Detect permanently banned accounts

**Problem:** Google permanently bans accounts for ToS violations with a 403:
```
Gemini has been disabled in this account for violation of Terms of Service.
```
The existing `isValidationRequired()` from #248 doesn't match this error (it only checks for `validation_required`, `account_disabled`, `user_disabled`). Banned accounts show as generic `ERROR` in the WebUI with no explanation, and the proxy keeps retrying them — wasting requests.

**Fix:**
- New `isAccountBanned()` function in `rate-limit-state.js`
- Hooked into `streaming-handler.js` and `message-handler.js` (marks invalid + rotates)
- Hooked into `model-api.js` (`fetchAvailableModels` + `getSubscriptionTier` — catches bans during quota fetch)
- Hooked into `server.js` `/account-limits` — returns distinct `status: 'banned'` (separate from `'invalid'`)
- WebUI changes in `accounts.html`:
  - **BANNED** label in dark red (distinct from red INVALID for fixable auth issues)
  - Ban reason shown as subtitle text below the status
  - **APPEAL** button (mailto link to `gemini-code-assist-user-feedback@google.com`) replaces the useless FIX button

### Files Changed
| File | Change |
|------|--------|
| `src/account-manager/storage.js` | Write lock + JSON validation + atomic write |
| `src/cloudcode/rate-limit-state.js` | New `isAccountBanned()` detection function |
| `src/cloudcode/streaming-handler.js` | Ban detection in streaming 403 handler |
| `src/cloudcode/message-handler.js` | Ban detection in non-streaming 403 handler |
| `src/cloudcode/model-api.js` | Ban detection in quota + subscription fetch |
| `src/server.js` | Surface `banned` status in `/account-limits` response |
| `public/views/accounts.html` | BANNED styling + APPEAL button |

### Testing
- Storage fix tested by running 15 accounts with frequent quota refreshes — no more corruption
- ToS ban detection tested against actual Google 403 responses from banned accounts
- Banned accounts now show distinct **BANNED** status in WebUI with dark-red styling and APPEAL button
- Regular auth failures (expired tokens, revoked access) still show **INVALID** with FIX button as before