### PR TITLE
chore: update claude-sonnet-4-5 model references to claude-sonnet-4-6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Antigravity Claude Proxy is a Node.js proxy server that exposes an Anthropic-compatible API backed by Antigravity's Cloud Code service. It enables using Claude models (`claude-sonnet-4-5-thinking`, `claude-opus-4-6-thinking`) and Gemini models (`gemini-3-flash`, `gemini-3.1-pro-low`, `gemini-3.1-pro-high`) with Claude Code CLI.
+Antigravity Claude Proxy is a Node.js proxy server that exposes an Anthropic-compatible API backed by Antigravity's Cloud Code service. It enables using Claude models (`claude-sonnet-4-6-thinking`, `claude-opus-4-6-thinking`) and Gemini models (`gemini-3-flash`, `gemini-3.1-pro-low`, `gemini-3.1-pro-high`) with Claude Code CLI.
 
 The proxy translates requests from Anthropic Messages API format → Google Generative AI format → Antigravity Cloud Code API, then converts responses back to Anthropic format with full thinking/streaming support.
 
@@ -266,7 +266,7 @@ Each account object in `accounts.json` contains:
 **Model Fallback (--fallback flag):**
 - When all accounts are exhausted for a model, automatically falls back to an alternate model
 - Fallback mappings defined in `MODEL_FALLBACK_MAP` in `src/constants.js`
-- Thinking models fall back to thinking models (e.g., `claude-sonnet-4-5-thinking` → `gemini-3-flash`)
+- Thinking models fall back to thinking models (e.g., `claude-sonnet-4-6-thinking` → `gemini-3-flash`)
 - Fallback is disabled on recursive calls to prevent infinite chains
 - Enable with `npm start -- --fallback` or `FALLBACK=true` environment variable
 

--- a/README.md
+++ b/README.md
@@ -187,9 +187,9 @@ Add this configuration:
     "ANTHROPIC_BASE_URL": "http://localhost:8080",
     "ANTHROPIC_MODEL": "claude-opus-4-6-thinking",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-6-thinking",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-5-thinking",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4-5",
-    "CLAUDE_CODE_SUBAGENT_MODEL": "claude-sonnet-4-5-thinking",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6-thinking",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4-6",
+    "CLAUDE_CODE_SUBAGENT_MODEL": "claude-sonnet-4-6-thinking",
     "ENABLE_EXPERIMENTAL_MCP_CLI": "true"
   }
 }

--- a/docs/models.md
+++ b/docs/models.md
@@ -4,9 +4,9 @@
 
 | Model ID                     | Description                              |
 | ---------------------------- | ---------------------------------------- |
-| `claude-sonnet-4-5-thinking` | Claude Sonnet 4.5 with extended thinking |
+| `claude-sonnet-4-6-thinking` | Claude Sonnet 4.6 with extended thinking |
 | `claude-opus-4-6-thinking`   | Claude Opus 4.6 with extended thinking   |
-| `claude-sonnet-4-5`          | Claude Sonnet 4.5 without thinking       |
+| `claude-sonnet-4-6`          | Claude Sonnet 4.6 without thinking       |
 
 ## Gemini Models
 

--- a/docs/openclaw.md
+++ b/docs/openclaw.md
@@ -45,8 +45,8 @@ Add the following configuration:
             "maxTokens": 65536
           },
           {
-            "id": "claude-sonnet-4-5",
-            "name": "Claude Sonnet 4.5",
+            "id": "claude-sonnet-4-6",
+            "name": "Claude Sonnet 4.6",
             "reasoning": false,
             "input": ["text", "image"],
             "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
@@ -54,8 +54,8 @@ Add the following configuration:
             "maxTokens": 16384
           },
           {
-            "id": "claude-sonnet-4-5-thinking",
-            "name": "Claude Sonnet 4.5 Thinking",
+            "id": "claude-sonnet-4-6-thinking",
+            "name": "Claude Sonnet 4.6 Thinking",
             "reasoning": true,
             "input": ["text", "image"],
             "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },

--- a/public/js/data-store.js
+++ b/public/js/data-store.js
@@ -81,7 +81,7 @@ document.addEventListener('alpine:init', () => {
                         this.models = data.models;
                         this.modelConfig = data.modelConfig || {};
                         this.usageHistory = data.usageHistory || {};
-                        
+
                         // Don't show loading on initial load if we have cache
                         this.initialLoad = false;
                         this.computeQuotaRows();
@@ -351,7 +351,7 @@ document.addEventListener('alpine:init', () => {
 
             this.quotaRows = rows.sort((a, b) => {
                 if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
-                
+
                 let valA = a[sortCol];
                 let valB = b[sortCol];
 
@@ -436,8 +436,8 @@ document.addEventListener('alpine:init', () => {
         _generatePlaceholderData() {
             const models = [
                 'claude-opus-4-6-thinking',
-                'claude-sonnet-4-5-thinking',
-                'claude-sonnet-4-5',
+                'claude-sonnet-4-6-thinking',
+                'claude-sonnet-4-6',
                 'gemini-3.1-pro-high',
                 'gemini-3.1-pro-low',
                 'gemini-3-flash'

--- a/src/constants.js
+++ b/src/constants.js
@@ -278,16 +278,16 @@ export const ANTIGRAVITY_SYSTEM_INSTRUCTION = `You are Antigravity, a powerful a
 // Model fallback mapping - maps primary model to fallback when quota exhausted
 export const MODEL_FALLBACK_MAP = {
     'gemini-3.1-pro-high': 'claude-opus-4-6-thinking',
-    'gemini-3.1-pro-low': 'claude-sonnet-4-5',
-    'gemini-3-flash': 'claude-sonnet-4-5-thinking',
+    'gemini-3.1-pro-low': 'claude-sonnet-4-6',
+    'gemini-3-flash': 'claude-sonnet-4-6-thinking',
     'claude-opus-4-6-thinking': 'gemini-3.1-pro-high',
-    'claude-sonnet-4-5-thinking': 'gemini-3-flash',
-    'claude-sonnet-4-5': 'gemini-3-flash'
+    'claude-sonnet-4-6-thinking': 'gemini-3-flash',
+    'claude-sonnet-4-6': 'gemini-3-flash'
 };
 
 // Default test models for each family (used by test suite)
 export const TEST_MODELS = {
-    claude: 'claude-sonnet-4-5-thinking',
+    claude: 'claude-sonnet-4-6-thinking',
     gemini: 'gemini-3-flash'
 };
 
@@ -300,9 +300,9 @@ export const DEFAULT_PRESETS = [
             ANTHROPIC_BASE_URL: 'http://localhost:8080',
             ANTHROPIC_MODEL: 'claude-opus-4-6-thinking',
             ANTHROPIC_DEFAULT_OPUS_MODEL: 'claude-opus-4-6-thinking',
-            ANTHROPIC_DEFAULT_SONNET_MODEL: 'claude-sonnet-4-5-thinking',
-            ANTHROPIC_DEFAULT_HAIKU_MODEL: 'claude-sonnet-4-5',
-            CLAUDE_CODE_SUBAGENT_MODEL: 'claude-sonnet-4-5-thinking',
+            ANTHROPIC_DEFAULT_SONNET_MODEL: 'claude-sonnet-4-6-thinking',
+            ANTHROPIC_DEFAULT_HAIKU_MODEL: 'claude-sonnet-4-6',
+            CLAUDE_CODE_SUBAGENT_MODEL: 'claude-sonnet-4-6-thinking',
             ENABLE_EXPERIMENTAL_MCP_CLI: 'true'
         }
     },

--- a/tests/test-streaming-whitespace.cjs
+++ b/tests/test-streaming-whitespace.cjs
@@ -67,7 +67,7 @@ async function runTests() {
         ];
 
         const response = new MockResponse(chunks);
-        const originalModel = 'claude-sonnet-4-5';
+        const originalModel = 'claude-sonnet-4-6';
 
         let fullText = '';
         const generator = streamSSEResponse(response, originalModel);
@@ -91,7 +91,7 @@ async function runTests() {
         ];
 
         const response = new MockResponse(chunks);
-        const originalModel = 'claude-sonnet-4-5';
+        const originalModel = 'claude-sonnet-4-6';
 
         let fullText = '';
         const generator = streamSSEResponse(response, originalModel);


### PR DESCRIPTION
## Summary
 
Update all model name references from `claude-sonnet-4-5` to `claude-sonnet-4-6` across the codebase to reflect the latest available model version.

## Files Changed

- `CLAUDE.md` - Updated model name in project overview and fallback examples
- `README.md` - Updated default model configuration examples
- `docs/models.md` - Updated model table entries
- `docs/openclaw.md` - Updated model IDs and names in configuration
- `public/js/data-store.js` - Updated placeholder data model names
- `src/constants.js` - Updated MODEL_FALLBACK_MAP, TEST_MODELS, and DEFAULT_PRESETS
- `tests/test-streaming-whitespace.cjs` - Updated test model references
