### PR TITLE
update to use environment variable override for FALLBACK_ANTIGRAVITY_VERSION

### DIFF
--- a/src/utils/version-detector.js
+++ b/src/utils/version-detector.js
@@ -9,8 +9,8 @@ import { existsSync } from 'fs';
  * Falls back to hard-coded stable versions if detection fails.
  */
 
-// Fallback constant
-const FALLBACK_ANTIGRAVITY_VERSION = '1.20.6';
+// Fallback constant (can be overridden via FALLBACK_ANTIGRAVITY_VERSION env var)
+const FALLBACK_ANTIGRAVITY_VERSION = process.env.FALLBACK_ANTIGRAVITY_VERSION || '1.20.6';
 
 // Cache for the generated User-Agent string
 let cachedUserAgent = null;


### PR DESCRIPTION
This is because google APIs seem to check the antigravity version and return a message instead of the real LLM response when the version is too old, adding this to an environment variable allows updating this easily by the user instead of relying on updating the hardcoded value.