### PR TITLE
fix: auto-detect X-Client-Version from local Antigravity product.json

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,8 @@ The proxy supports the following environment variables:
 | `DEBUG` | Enable debug logging (`true`/`false`) | `false` |
 | `DEV_MODE` | Enable developer mode (`true`/`false`) | `false` |
 | `FALLBACK` | Enable model fallback (`true`/`false`) | `false` |
-| `FALLBACK_ANTIGRAVITY_VERSION` | Override the Antigravity version string sent in requests (useful when Google APIs reject old versions) | `1.23.2` |
+| `FALLBACK_ANTIGRAVITY_VERSION` | Override the User-Agent version string (ideVersion) | `1.23.2` |
+| `ANTIGRAVITY_CLIENT_VERSION` | Override the X-Client-Version header sent to the API (prevents "no longer supported" errors) | Auto-detected from product.json |
 | `CLAUDE_CONFIG_PATH` | Path to `.claude` directory for CLI settings (for systemd/service deployments) | `~/.claude` |
 
 ### Setting Environment Variables

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,7 @@ The proxy supports the following environment variables:
 | `FALLBACK` | Enable model fallback (`true`/`false`) | `false` |
 | `FALLBACK_ANTIGRAVITY_VERSION` | Override the User-Agent version string (useful when Google APIs reject old versions) | `1.23.2` |
 | `ANTIGRAVITY_CLIENT_VERSION` | Override the X-Client-Version header sent to the API (prevents "no longer supported" errors) | Auto-detected from product.json |
+| `ANTIGRAVITY_CLIENT_VERSION_FALLBACK` | Override the fallback X-Client-Version (used when product.json is not found) | `1.110.0` |
 | `CLAUDE_CONFIG_PATH` | Path to `.claude` directory for CLI settings (for systemd/service deployments) | `~/.claude` |
 
 ### Setting Environment Variables

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,7 @@ The proxy supports the following environment variables:
 | `DEBUG` | Enable debug logging (`true`/`false`) | `false` |
 | `DEV_MODE` | Enable developer mode (`true`/`false`) | `false` |
 | `FALLBACK` | Enable model fallback (`true`/`false`) | `false` |
-| `FALLBACK_ANTIGRAVITY_VERSION` | Override the User-Agent version string (ideVersion) | `1.23.2` |
+| `FALLBACK_ANTIGRAVITY_VERSION` | Override the User-Agent version string (useful when Google APIs reject old versions) | `1.23.2` |
 | `ANTIGRAVITY_CLIENT_VERSION` | Override the X-Client-Version header sent to the API (prevents "no longer supported" errors) | Auto-detected from product.json |
 | `CLAUDE_CONFIG_PATH` | Path to `.claude` directory for CLI settings (for systemd/service deployments) | `~/.claude` |
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,7 +6,7 @@
 import { homedir, platform, arch } from 'os';
 import { join } from 'path';
 import { config } from './config.js';
-import { generateSmartUserAgent } from './utils/version-detector.js';
+import { generateSmartUserAgent, getClientVersion } from './utils/version-detector.js';
 
 /**
  * Get the Antigravity database path based on the current platform.
@@ -104,7 +104,7 @@ export const ANTIGRAVITY_HEADERS = {
     'User-Agent': getPlatformUserAgent(),
     'Content-Type': 'application/json',
     'X-Client-Name': 'antigravity',
-    'X-Client-Version': '1.107.0', // Match product.json version
+    'X-Client-Version': getClientVersion(),
     'x-goog-api-client': 'gl-node/18.18.2 fire/0.8.6 grpc/1.10.x' // Simulate Google Node.js client environment
 };
 

--- a/src/utils/version-detector.js
+++ b/src/utils/version-detector.js
@@ -27,6 +27,7 @@ const FALLBACK_CLIENT_VERSION = '1.110.0';
 let cachedUserAgent = null;
 let cachedClientVersion = null;
 let cachedProductJson = undefined; // undefined = not yet attempted
+let loggedVersionInfo = false;
 
 /**
  * Compares two semver-ish version strings (X.Y.Z).
@@ -54,6 +55,7 @@ function getProductJsonPaths() {
 
     if (os === 'darwin') {
         paths.push('/Applications/Antigravity.app/Contents/Resources/app/product.json');
+        paths.push(join(homedir(), 'Applications', 'Antigravity.app', 'Contents', 'Resources', 'app', 'product.json'));
     } else if (os === 'win32') {
         const localAppData = process.env.LOCALAPPDATA;
         const programFiles = process.env.ProgramFiles || 'C:\\Program Files';
@@ -99,6 +101,22 @@ function getProductJson() {
 }
 
 /**
+ * Log version detection results once at startup (lazy import to avoid circular deps).
+ */
+function logVersionInfo(version, source) {
+    if (loggedVersionInfo) return;
+    loggedVersionInfo = true;
+
+    import('./logger.js').then(({ logger }) => {
+        if (source === 'fallback') {
+            logger.warn(`X-Client-Version: using hardcoded fallback ${version} — product.json not found. Set ANTIGRAVITY_CLIENT_VERSION env var to override.`);
+        } else {
+            logger.debug(`X-Client-Version: ${version} (source: ${source})`);
+        }
+    }).catch(() => {});
+}
+
+/**
  * Get the X-Client-Version value for API requests.
  * Priority: ANTIGRAVITY_CLIENT_VERSION env var > product.json "version" > hardcoded fallback
  * @returns {string} Version string (e.g. "1.110.0")
@@ -108,16 +126,19 @@ export function getClientVersion() {
 
     if (process.env.ANTIGRAVITY_CLIENT_VERSION) {
         cachedClientVersion = process.env.ANTIGRAVITY_CLIENT_VERSION;
+        logVersionInfo(cachedClientVersion, 'env');
         return cachedClientVersion;
     }
 
     const product = getProductJson();
-    if (product?.version && isVersionHigher(product.version, FALLBACK_CLIENT_VERSION)) {
+    if (product?.version) {
         cachedClientVersion = product.version;
+        logVersionInfo(cachedClientVersion, 'product.json');
         return cachedClientVersion;
     }
 
     cachedClientVersion = FALLBACK_CLIENT_VERSION;
+    logVersionInfo(cachedClientVersion, 'fallback');
     return cachedClientVersion;
 }
 

--- a/src/utils/version-detector.js
+++ b/src/utils/version-detector.js
@@ -1,24 +1,35 @@
 import { execSync } from 'child_process';
 import { platform, homedir } from 'os';
 import { join } from 'path';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 
 /**
  * Intelligent Version Detection for Antigravity
- * Attempts to find the local installation and extract its version.
- * Falls back to hard-coded stable versions if detection fails.
+ *
+ * Detects versions from the local Antigravity installation's product.json.
+ * Two version values are tracked:
+ *   - "version" field      → X-Client-Version header (API version gate)
+ *   - "ideVersion" field   → User-Agent version string
+ *
+ * Detection priority (for each):
+ *   1. Environment variable override
+ *   2. product.json from local Antigravity app
+ *   3. OS-specific detection (macOS plist / Windows exe)
+ *   4. Hardcoded fallback
  */
 
-// Fallback constant (can be overridden via FALLBACK_ANTIGRAVITY_VERSION env var)
-const FALLBACK_ANTIGRAVITY_VERSION = process.env.FALLBACK_ANTIGRAVITY_VERSION || '1.23.2';
+// Fallback for User-Agent version (ideVersion in product.json)
+const FALLBACK_USER_AGENT_VERSION = process.env.FALLBACK_ANTIGRAVITY_VERSION || '1.23.2';
 
-// Cache for the generated User-Agent string
+// Fallback for X-Client-Version (top-level "version" in product.json)
+const FALLBACK_CLIENT_VERSION = '1.110.0';
+
 let cachedUserAgent = null;
+let cachedClientVersion = null;
+let cachedProductJson = undefined; // undefined = not yet attempted
 
 /**
  * Compares two semver-ish version strings (X.Y.Z).
- * @param {string} v1 - Version string 1
- * @param {string} v2 - Version string 2
  * @returns {boolean} True if v1 > v2
  */
 function isVersionHigher(v1, v2) {
@@ -35,15 +46,99 @@ function isVersionHigher(v1, v2) {
 }
 
 /**
- * Gets the version config (version, source)
+ * Returns platform-specific search paths for product.json.
+ */
+function getProductJsonPaths() {
+    const os = platform();
+    const paths = [];
+
+    if (os === 'darwin') {
+        paths.push('/Applications/Antigravity.app/Contents/Resources/app/product.json');
+    } else if (os === 'win32') {
+        const localAppData = process.env.LOCALAPPDATA;
+        const programFiles = process.env.ProgramFiles || 'C:\\Program Files';
+        if (localAppData) {
+            paths.push(join(localAppData, 'Programs', 'Antigravity', 'resources', 'app', 'product.json'));
+        }
+        paths.push(join(programFiles, 'Antigravity', 'resources', 'app', 'product.json'));
+    } else {
+        paths.push('/usr/share/antigravity/resources/app/product.json');
+        paths.push('/opt/antigravity/resources/app/product.json');
+        paths.push('/opt/Antigravity/resources/app/product.json');
+        paths.push(join(homedir(), '.local', 'share', 'antigravity', 'resources', 'app', 'product.json'));
+        paths.push('/snap/antigravity/current/resources/app/product.json');
+    }
+
+    return paths;
+}
+
+/**
+ * Find and parse product.json from the local Antigravity installation.
+ * Caches the result after first attempt.
+ * @returns {Object|null} Parsed product.json or null
+ */
+function getProductJson() {
+    if (cachedProductJson !== undefined) return cachedProductJson;
+
+    for (const p of getProductJsonPaths()) {
+        try {
+            if (existsSync(p)) {
+                const content = JSON.parse(readFileSync(p, 'utf8'));
+                if (content && (content.version || content.ideVersion)) {
+                    cachedProductJson = content;
+                    return content;
+                }
+            }
+        } catch (e) {
+            // Continue to next path
+        }
+    }
+
+    cachedProductJson = null;
+    return null;
+}
+
+/**
+ * Get the X-Client-Version value for API requests.
+ * Priority: ANTIGRAVITY_CLIENT_VERSION env var > product.json "version" > hardcoded fallback
+ * @returns {string} Version string (e.g. "1.110.0")
+ */
+export function getClientVersion() {
+    if (cachedClientVersion) return cachedClientVersion;
+
+    if (process.env.ANTIGRAVITY_CLIENT_VERSION) {
+        cachedClientVersion = process.env.ANTIGRAVITY_CLIENT_VERSION;
+        return cachedClientVersion;
+    }
+
+    const product = getProductJson();
+    if (product?.version && isVersionHigher(product.version, FALLBACK_CLIENT_VERSION)) {
+        cachedClientVersion = product.version;
+        return cachedClientVersion;
+    }
+
+    cachedClientVersion = FALLBACK_CLIENT_VERSION;
+    return cachedClientVersion;
+}
+
+/**
+ * Get the User-Agent version string.
+ * Priority: FALLBACK_ANTIGRAVITY_VERSION env var > product.json "ideVersion" > OS detection > fallback
  * @returns {{ version: string, source: string }}
  */
-function getVersionConfig() {
+function getUserAgentVersionConfig() {
+    if (process.env.FALLBACK_ANTIGRAVITY_VERSION) {
+        return { version: process.env.FALLBACK_ANTIGRAVITY_VERSION, source: 'env' };
+    }
+
+    const product = getProductJson();
+    if (product?.ideVersion && isVersionHigher(product.ideVersion, FALLBACK_USER_AGENT_VERSION)) {
+        return { version: product.ideVersion, source: 'product.json' };
+    }
+
+    // OS-specific detection (legacy — reads app binary metadata directly)
     const os = platform();
     let detectedVersion = null;
-    let finalVersion = FALLBACK_ANTIGRAVITY_VERSION;
-    let source = 'fallback';
-
     try {
         if (os === 'darwin') {
             detectedVersion = getVersionMacos();
@@ -54,16 +149,11 @@ function getVersionConfig() {
         // Silently fail and use fallback
     }
 
-    // Only use detected version if it's higher than the fallback version
-    if (detectedVersion && isVersionHigher(detectedVersion, FALLBACK_ANTIGRAVITY_VERSION)) {
-        finalVersion = detectedVersion;
-        source = 'local';
+    if (detectedVersion && isVersionHigher(detectedVersion, FALLBACK_USER_AGENT_VERSION)) {
+        return { version: detectedVersion, source: 'local' };
     }
 
-    return {
-        version: finalVersion,
-        source
-    };
+    return { version: FALLBACK_USER_AGENT_VERSION, source: 'fallback' };
 }
 
 /**
@@ -74,11 +164,10 @@ function getVersionConfig() {
 export function generateSmartUserAgent() {
     if (cachedUserAgent) return cachedUserAgent;
 
-    const { version } = getVersionConfig();
+    const { version } = getUserAgentVersionConfig();
     const os = platform();
     const architecture = process.arch;
 
-    // Map Node.js platform names to binary-friendly names
     const osName = os === 'darwin' ? 'darwin' : (os === 'win32' ? 'win32' : 'linux');
 
     cachedUserAgent = `antigravity/${version} ${osName}/${architecture}`;
@@ -131,4 +220,3 @@ function getVersionWindows() {
     }
     return null;
 }
-

--- a/src/utils/version-detector.js
+++ b/src/utils/version-detector.js
@@ -22,7 +22,8 @@ import { existsSync, readFileSync } from 'fs';
 const FALLBACK_USER_AGENT_VERSION = process.env.FALLBACK_ANTIGRAVITY_VERSION || '1.23.2';
 
 // Fallback for X-Client-Version (top-level "version" in product.json)
-const FALLBACK_CLIENT_VERSION = '1.110.0';
+// Can be overridden via ANTIGRAVITY_CLIENT_VERSION_FALLBACK env var
+const FALLBACK_CLIENT_VERSION = process.env.ANTIGRAVITY_CLIENT_VERSION_FALLBACK || '1.110.0';
 
 let cachedUserAgent = null;
 let cachedClientVersion = null;
@@ -109,7 +110,7 @@ function logVersionInfo(version, source) {
 
     import('./logger.js').then(({ logger }) => {
         if (source === 'fallback') {
-            logger.warn(`X-Client-Version: using hardcoded fallback ${version} — product.json not found. Set ANTIGRAVITY_CLIENT_VERSION env var to override.`);
+            logger.warn(`X-Client-Version: using hardcoded fallback ${version} — product.json not found. Set ANTIGRAVITY_CLIENT_VERSION (exact version) or ANTIGRAVITY_CLIENT_VERSION_FALLBACK (fallback value) env var to override.`);
         } else {
             logger.debug(`X-Client-Version: ${version} (source: ${source})`);
         }


### PR DESCRIPTION
The X-Client-Version header was hardcoded in constants.js and broke every time Antigravity raised its minimum supported version, causing `"This version antigravity is no longer supported"` errors for all users.

This commit reads the version from the locally installed Antigravity app's product.json (supports macOS, Windows, and Linux install paths) and falls back to a hardcoded default only when detection fails.

Adds ANTIGRAVITY_CLIENT_VERSION env var as an escape hatch override.

Closes #333 