### PR TITLE
Fix: API Error: 400 invalid_request_error

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -311,11 +311,11 @@ export const DEFAULT_PRESETS = [
         config: {
             ANTHROPIC_AUTH_TOKEN: 'test',
             ANTHROPIC_BASE_URL: 'http://localhost:8080',
-            ANTHROPIC_MODEL: 'gemini-3.1-pro-high[1m]',
-            ANTHROPIC_DEFAULT_OPUS_MODEL: 'gemini-3.1-pro-high[1m]',
-            ANTHROPIC_DEFAULT_SONNET_MODEL: 'gemini-3.1-flash[1m]',
-            ANTHROPIC_DEFAULT_HAIKU_MODEL: 'gemini-3.1-flash[1m]',
-            CLAUDE_CODE_SUBAGENT_MODEL: 'gemini-3.1-flash[1m]',
+            ANTHROPIC_MODEL: 'gemini-3.1-pro-high',
+            ANTHROPIC_DEFAULT_OPUS_MODEL: 'gemini-3.1-pro-high',
+            ANTHROPIC_DEFAULT_SONNET_MODEL: 'gemini-3.1-flash',
+            ANTHROPIC_DEFAULT_HAIKU_MODEL: 'gemini-3.1-flash',
+            CLAUDE_CODE_SUBAGENT_MODEL: 'gemini-3.1-flash',
             ENABLE_EXPERIMENTAL_MCP_CLI: 'true'
         }
     }


### PR DESCRIPTION
🐛 The Problem
While using the "Gemini 1M" preset, I encountered persistent API Error: 400 invalid_request_error (Status: INVALID_ARGUMENT) when making calls to the Google Gemini API.

After investigating the logs and source code, I identified that the [1m] suffix, intended as a feature flag for context length, is being hardcoded directly into the model identifiers in src/constants.js.

🔍 Root Cause
The Google Gemini API (unlike Anthropic/OpenAI) strictly validates model names against a specific regex. Because [1m] is not part of the official model naming convention, the upstream API rejects the request as an invalid argument before processing. This also causes state corruption in the user's global ~/.claude.json when the "Apply to Claude CLI" action is triggered.

🛠️ The Fix
This PR removes the hardcoded [1m] suffixes from the Gemini model presets in src/constants.js. This allows the proxy to pass clean, valid model strings (e.g., gemini-3.1-pro-high) to the upstream API while still allowing users to benefit from the 1M context window of the 3.1 series.

🤝 Community Credit
This also addresses the issue raised by @FaintShadow in #335. Thanks for flagging this!