### PR TITLE
feat: add GPT-OSS model family support

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+    apps: [
+        {
+            name: 'antigravity-proxy',
+            cwd: __dirname,
+            script: 'src/index.js',
+            interpreter: 'node',
+            exec_mode: 'fork',
+            instances: 1,
+            autorestart: true,
+            watch: false,
+            windowsHide: true,
+            max_memory_restart: '512M'
+        }
+    ]
+};

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "test:emptyretry": "node tests/test-empty-response-retry.cjs",
     "test:sanitizer": "node tests/test-schema-sanitizer.cjs",
     "test:strategies": "node tests/test-strategies.cjs",
-    "test:cache-control": "node tests/test-cache-control.cjs"
+    "test:cache-control": "node tests/test-cache-control.cjs",
+    "test:grok": "node --test tests/test-grok-bridge.test.cjs"
   },
   "keywords": [
     "claude",

--- a/public/js/components/model-dropdown.js
+++ b/public/js/components/model-dropdown.js
@@ -44,6 +44,7 @@ window.Components.modelDropdown = (field, labelKey, accentColor) => ({
         const groups = [
             { family: 'claude', label: this.$store.global.t('familyClaude'), items: [] },
             { family: 'gemini', label: this.$store.global.t('familyGemini'), items: [] },
+            { family: 'gpt-oss', label: 'GPT-OSS', items: [] },
             { family: 'other', label: this.$store.global.t('familyOther'), items: [] }
         ];
         for (const modelId of this.filteredModels) {

--- a/public/js/data-store.js
+++ b/public/js/data-store.js
@@ -390,6 +390,7 @@ document.addEventListener('alpine:init', () => {
             const lower = modelId.toLowerCase();
             if (lower.includes('claude')) return 'claude';
             if (lower.includes('gemini')) return 'gemini';
+            if (lower.includes('gpt-oss')) return 'gpt-oss';
             return 'other';
         },
 

--- a/public/views/models.html
+++ b/public/views/models.html
@@ -86,6 +86,13 @@
                     @click="$store.data.filters.family = 'gemini'; $store.data.computeQuotaRows()"
                     x-text="$store.global.t('geminiCaps')">GEMINI</button>
             </div>
+              <button
+                    class="join-item btn btn-xs h-full flex-1 md:flex-none px-6 border-space-border/50 bg-space-800 transition-all font-medium text-[10px] tracking-wide"
+                    :class="$store.data.filters.family === 'gpt-oss'
+                        ? 'bg-neon-cyan/20 text-neon-cyan border-neon-cyan/60 shadow-lg shadow-neon-cyan/10'
+                        : 'text-gray-400 hover:text-white hover:bg-space-700 hover:border-space-border'"
+                    @click="$store.data.filters.family = 'gpt-oss'; $store.data.computeQuotaRows()"
+                    >GPT</button>
 
             <!-- Show Hidden Toggle -->
             <button

--- a/src/cloudcode/grok-bridge.js
+++ b/src/cloudcode/grok-bridge.js
@@ -1,7 +1,7 @@
 /**
  * Anthropic-compatible bridge to the Grok CLI.
  */
-import { spawn as nodeSpawn } from 'child_process';
+import { spawn as nodeSpawn, spawnSync as nodeSpawnSync } from 'child_process';
 import crypto from 'crypto';
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'fs';
 import { homedir, tmpdir } from 'os';
@@ -57,7 +57,11 @@ export function buildGrokLaunch(commandSpec, args, {
     const options = { shell: false, windowsHide: platform === 'win32' };
     if (platform === 'win32' && commandSpec.kind === 'cmd') {
         const commandLine = [commandSpec.command, ...args].map(quoteCmdToken).join(' ');
-        return { command: comSpec, args: ['/d', '/s', '/c', commandLine], options };
+        return {
+            command: comSpec,
+            args: ['/d', '/s', '/c', commandLine],
+            options: { ...options, windowsVerbatimArguments: true }
+        };
     }
     return { command: commandSpec.command, args, options };
 }
@@ -92,6 +96,24 @@ export function spawnGrokProcess(args, {
         stdio,
         env: buildEnv(homeDir, baseEnv)
     });
+}
+
+export function terminateGrokProcess(child, {
+    platform = process.platform,
+    spawnSyncImpl = nodeSpawnSync,
+    systemRoot = process.env.SystemRoot || 'C:\\Windows'
+} = {}) {
+    if (platform === 'win32' && Number.isInteger(child.pid)) {
+        const taskkill = join(systemRoot, 'System32', 'taskkill.exe');
+        const result = spawnSyncImpl(taskkill, ['/pid', String(child.pid), '/t', '/f'], {
+            stdio: 'ignore',
+            shell: false,
+            windowsHide: true
+        });
+        if (!result.error && result.status === 0) return true;
+    }
+    try { child.kill(); } catch { /* process already exited */ }
+    return false;
 }
 
 function buildGrokPrompt(anthropicRequest) {
@@ -176,6 +198,7 @@ export function createGrokBridge({
     grokCommand = resolveGrokCommand({ platform }),
     comSpec = process.env.ComSpec || 'cmd.exe',
     baseEnv = process.env,
+    terminateProcess = child => terminateGrokProcess(child, { platform }),
     healthTimeoutMs = DEFAULT_HEALTH_TIMEOUT_MS,
     requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS
 } = {}) {
@@ -195,10 +218,13 @@ export function createGrokBridge({
             let stdout = '';
             let stderr = '';
             let settled = false;
+            let terminationError = null;
+            let terminationGraceTimer = null;
             const finish = (callback, value) => {
                 if (settled) return;
                 settled = true;
                 clearTimeout(timer);
+                clearTimeout(terminationGraceTimer);
                 signal?.removeEventListener('abort', onAbort);
                 child.stdout?.destroy();
                 child.stderr?.destroy();
@@ -206,8 +232,13 @@ export function createGrokBridge({
                 callback(value);
             };
             const terminate = error => {
-                try { child.kill(); } catch { /* process already exited */ }
-                finish(reject, error);
+                terminationError = error;
+                const treeTerminated = terminateProcess(child);
+                if (treeTerminated) {
+                    finish(reject, error);
+                    return;
+                }
+                terminationGraceTimer = setTimeout(() => finish(reject, error), 2_000);
             };
             const onAbort = () => terminate(createAbortError());
             const timer = setTimeout(() => terminate(createTimeoutError(timeoutMs)), timeoutMs);
@@ -215,7 +246,13 @@ export function createGrokBridge({
             child.stdout?.on('data', data => { stdout += data.toString(); });
             child.stderr?.on('data', data => { stderr += data.toString(); });
             child.on('error', error => finish(reject, new Error(`Grok CLI unavailable: ${error.message}`)));
-            child.on('close', (code, childSignal) => finish(resolve, { code, signal: childSignal, stdout, stderr }));
+            child.on('close', (code, childSignal) => {
+                if (terminationError) {
+                    finish(reject, terminationError);
+                    return;
+                }
+                finish(resolve, { code, signal: childSignal, stdout, stderr });
+            });
             signal?.addEventListener('abort', onAbort, { once: true });
         });
     }

--- a/src/cloudcode/grok-bridge.js
+++ b/src/cloudcode/grok-bridge.js
@@ -1,0 +1,328 @@
+/**
+ * Anthropic-compatible bridge to the Grok CLI.
+ */
+import { spawn as nodeSpawn } from 'child_process';
+import crypto from 'crypto';
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'fs';
+import { homedir, tmpdir } from 'os';
+import { delimiter, join } from 'path';
+import { GrokAccountManager } from '../grok/grok-account-manager.js';
+import { logger } from '../utils/logger.js';
+
+const DEFAULT_HEALTH_TIMEOUT_MS = 10_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
+const GROK_BIN_DIR = join(homedir(), '.grok', 'bin');
+
+function findOnPath(fileName, env, existsSyncImpl) {
+    for (const directory of (env.PATH || '').split(delimiter).filter(Boolean)) {
+        const candidate = join(directory.replace(/^"|"$/g, ''), fileName);
+        if (existsSyncImpl(candidate)) return candidate;
+    }
+    return null;
+}
+
+export function resolveGrokCommand({
+    platform = process.platform,
+    homeDir = homedir(),
+    env = process.env,
+    existsSyncImpl = existsSync
+} = {}) {
+    const binDir = join(homeDir, '.grok', 'bin');
+    if (platform === 'win32') {
+        const preferredExe = join(binDir, 'grok.exe');
+        if (existsSyncImpl(preferredExe)) return { command: preferredExe, kind: 'executable' };
+        const preferredCmd = join(binDir, 'grok.cmd');
+        if (existsSyncImpl(preferredCmd)) return { command: preferredCmd, kind: 'cmd' };
+        const pathExe = findOnPath('grok.exe', env, existsSyncImpl);
+        if (pathExe) return { command: pathExe, kind: 'executable' };
+        const pathCmd = findOnPath('grok.cmd', env, existsSyncImpl);
+        if (pathCmd) return { command: pathCmd, kind: 'cmd' };
+    } else {
+        const preferred = join(binDir, 'grok');
+        if (existsSyncImpl(preferred)) return { command: preferred, kind: 'executable' };
+    }
+    return { command: 'grok', kind: 'executable' };
+}
+
+function quoteCmdToken(value) {
+    const token = String(value);
+    if (/\r|\n|\0/.test(token)) throw new Error('Invalid newline in Grok CLI argument');
+    return `"${token.replace(/%/g, '%%').replace(/"/g, '""')}"`;
+}
+
+export function buildGrokLaunch(commandSpec, args, {
+    platform = process.platform,
+    comSpec = process.env.ComSpec || 'cmd.exe'
+} = {}) {
+    const options = { shell: false, windowsHide: platform === 'win32' };
+    if (platform === 'win32' && commandSpec.kind === 'cmd') {
+        const commandLine = [commandSpec.command, ...args].map(quoteCmdToken).join(' ');
+        return { command: comSpec, args: ['/d', '/s', '/c', commandLine], options };
+    }
+    return { command: commandSpec.command, args, options };
+}
+
+function buildEnv(homeDir, baseEnv) {
+    const currentPath = baseEnv.PATH || '';
+    const fullPath = currentPath.includes(GROK_BIN_DIR)
+        ? currentPath
+        : `${GROK_BIN_DIR}${delimiter}${currentPath}`;
+    return {
+        ...baseEnv,
+        PATH: fullPath,
+        USERPROFILE: homeDir,
+        HOME: homeDir,
+        GROK_MEMORY: '0',
+        GROK_SUBAGENTS: '0'
+    };
+}
+
+export function spawnGrokProcess(args, {
+    homeDir,
+    stdio = ['ignore', 'pipe', 'pipe'],
+    spawnImpl = nodeSpawn,
+    platform = process.platform,
+    grokCommand = resolveGrokCommand({ platform }),
+    comSpec = process.env.ComSpec || 'cmd.exe',
+    baseEnv = process.env
+} = {}) {
+    const launch = buildGrokLaunch(grokCommand, args, { platform, comSpec });
+    return spawnImpl(launch.command, launch.args, {
+        ...launch.options,
+        stdio,
+        env: buildEnv(homeDir, baseEnv)
+    });
+}
+
+function buildGrokPrompt(anthropicRequest) {
+    const { messages, system } = anthropicRequest;
+    let prompt = '';
+    if (system) {
+        if (typeof system === 'string') prompt += `${system}\n\n`;
+        else if (Array.isArray(system)) {
+            prompt += `${system.map(block => block.text || '').filter(Boolean).join('\n')}\n\n`;
+        }
+    }
+    for (const message of messages || []) {
+        const role = message.role === 'assistant' ? 'Assistant' : 'Human';
+        if (typeof message.content === 'string') {
+            prompt += `\n\n${role}: ${message.content}`;
+        } else if (Array.isArray(message.content)) {
+            for (const block of message.content) {
+                if (block.type === 'text') prompt += `\n\n${role}: ${block.text}`;
+                else if (block.type === 'tool_use') prompt += `\n\n${role}: [Using tool ${block.name}]`;
+                else if (block.type === 'tool_result') prompt += `\n\n${role}: [Tool result received]`;
+            }
+        }
+    }
+    return `${prompt}\n\nAssistant:`;
+}
+
+function parseGrokResponse(grokJson, model) {
+    let stopReason = 'end_turn';
+    if (grokJson.stopReason === 'max_tokens' || grokJson.stopReason === 'MAX_TOKENS') {
+        stopReason = 'max_tokens';
+    } else if (grokJson.stopReason === 'tool_use' || grokJson.stopReason === 'TOOL_USE') {
+        stopReason = 'tool_use';
+    }
+    return {
+        id: `msg_${crypto.randomBytes(16).toString('hex')}`,
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: grokJson.text || '' }],
+        model,
+        stop_reason: stopReason,
+        stop_sequence: null,
+        usage: {
+            input_tokens: grokJson.usage?.input_tokens || 0,
+            output_tokens: grokJson.usage?.output_tokens || 0
+        }
+    };
+}
+
+function isRateLimited(code, stderr, json) {
+    if (code === 0) return false;
+    const lower = stderr.toLowerCase();
+    if (lower.includes('rate limit') || lower.includes('429') || lower.includes('too many requests')) return true;
+    if (code === 1 && json?.stopReason === 'Cancelled') return false;
+    return code !== 0 && code !== null;
+}
+
+function writePromptFile(prompt) {
+    const directory = join(tmpdir(), 'grok-bridge');
+    mkdirSync(directory, { recursive: true });
+    const filePath = join(directory, `prompt-${Date.now()}-${crypto.randomBytes(4).toString('hex')}.txt`);
+    writeFileSync(filePath, prompt, 'utf-8');
+    return filePath;
+}
+
+function createTimeoutError(timeoutMs) {
+    const error = new Error(`Grok CLI request timed out after ${timeoutMs}ms`);
+    error.code = 'ETIMEDOUT';
+    return error;
+}
+
+function createAbortError() {
+    const error = new Error('Grok CLI request aborted');
+    error.name = 'AbortError';
+    error.code = 'ABORT_ERR';
+    return error;
+}
+
+export function createGrokBridge({
+    accountManager = new GrokAccountManager(),
+    spawnImpl = nodeSpawn,
+    platform = process.platform,
+    grokCommand = resolveGrokCommand({ platform }),
+    comSpec = process.env.ComSpec || 'cmd.exe',
+    baseEnv = process.env,
+    healthTimeoutMs = DEFAULT_HEALTH_TIMEOUT_MS,
+    requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS
+} = {}) {
+    function runGrok(args, account, { signal, timeoutMs, stdio = ['ignore', 'pipe', 'pipe'] } = {}) {
+        if (signal?.aborted) return Promise.reject(createAbortError());
+        const child = spawnGrokProcess(args, {
+            homeDir: account.homeDir,
+            stdio,
+            spawnImpl,
+            platform,
+            grokCommand,
+            comSpec,
+            baseEnv
+        });
+
+        return new Promise((resolve, reject) => {
+            let stdout = '';
+            let stderr = '';
+            let settled = false;
+            const finish = (callback, value) => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timer);
+                signal?.removeEventListener('abort', onAbort);
+                child.stdout?.destroy();
+                child.stderr?.destroy();
+                child.unref?.();
+                callback(value);
+            };
+            const terminate = error => {
+                try { child.kill(); } catch { /* process already exited */ }
+                finish(reject, error);
+            };
+            const onAbort = () => terminate(createAbortError());
+            const timer = setTimeout(() => terminate(createTimeoutError(timeoutMs)), timeoutMs);
+
+            child.stdout?.on('data', data => { stdout += data.toString(); });
+            child.stderr?.on('data', data => { stderr += data.toString(); });
+            child.on('error', error => finish(reject, new Error(`Grok CLI unavailable: ${error.message}`)));
+            child.on('close', (code, childSignal) => finish(resolve, { code, signal: childSignal, stdout, stderr }));
+            signal?.addEventListener('abort', onAbort, { once: true });
+        });
+    }
+
+    async function checkGrokAvailable({ signal } = {}) {
+        await accountManager.initialize();
+        const account = accountManager.selectAccount();
+        if (!account) return false;
+        try {
+            const result = await runGrok(['--version'], account, {
+                signal,
+                timeoutMs: healthTimeoutMs,
+                stdio: ['ignore', 'ignore', 'ignore']
+            });
+            return result.code === 0;
+        } catch {
+            return false;
+        }
+    }
+
+    async function runRequest(account, prompt, model, { signal } = {}) {
+        const promptFile = writePromptFile(prompt);
+        try {
+            const result = await runGrok(
+                ['--prompt-file', promptFile, '--output-format', 'json', '--max-turns', '1'],
+                account,
+                { signal, timeoutMs: requestTimeoutMs }
+            );
+            const jsonMatch = result.stdout.match(/\{[\s\S]*\}/);
+            let parsed = null;
+            if (jsonMatch) {
+                try { parsed = JSON.parse(jsonMatch[0]); } catch { /* invalid JSON handled below */ }
+            }
+            if (isRateLimited(result.code, result.stderr, parsed)) {
+                throw Object.assign(new Error('Rate limited'), { rateLimited: true });
+            }
+            if (!parsed) {
+                const output = result.stdout.substring(0, 200) || result.stderr.substring(0, 200);
+                throw new Error(`Grok CLI returned no valid JSON. Output: ${output}`);
+            }
+            return parseGrokResponse(parsed, model);
+        } finally {
+            try { unlinkSync(promptFile); } catch { /* already removed */ }
+        }
+    }
+
+    async function sendGrokMessage(anthropicRequest, options = {}) {
+        const model = anthropicRequest.model || 'grok-4.5';
+        const prompt = buildGrokPrompt(anthropicRequest);
+        await accountManager.initialize();
+        const maxAttempts = Math.max(1, accountManager.getAccounts().length || 1);
+
+        for (let attempt = 0; attempt < maxAttempts; attempt++) {
+            const account = accountManager.selectAccount();
+            if (!account) throw new Error('All Grok accounts are rate-limited or unavailable');
+            logger.debug(`[GrokBridge] Try ${attempt + 1}/${maxAttempts} account=${account.alias}`);
+            try {
+                const response = await runRequest(account, prompt, model, options);
+                accountManager.markSuccess(account.alias);
+                return response;
+            } catch (error) {
+                if (error.name === 'AbortError' || error.code === 'ETIMEDOUT') throw error;
+                if (error.rateLimited) {
+                    accountManager.markRateLimited(account.alias, 'Rate limited');
+                    logger.warn(`[GrokBridge] Account ${account.alias} rate-limited, trying next`);
+                    continue;
+                }
+                accountManager.markRateLimited(account.alias, error.message);
+                throw error;
+            }
+        }
+        throw new Error(`All Grok accounts are rate-limited after ${maxAttempts} attempts`);
+    }
+
+    async function* sendGrokMessageStream(anthropicRequest, options = {}) {
+        const model = anthropicRequest.model || 'grok-4.5';
+        const response = await sendGrokMessage(anthropicRequest, options);
+        const text = response.content[0]?.text || '';
+        yield {
+            type: 'message_start',
+            message: {
+                id: response.id,
+                type: 'message',
+                role: 'assistant',
+                content: [],
+                model,
+                stop_reason: null,
+                stop_sequence: null,
+                usage: { input_tokens: response.usage.input_tokens, output_tokens: 0 }
+            }
+        };
+        yield { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } };
+        if (text) yield { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text } };
+        yield { type: 'content_block_stop', index: 0 };
+        yield {
+            type: 'message_delta',
+            delta: { stop_reason: response.stop_reason || 'end_turn', stop_sequence: null },
+            usage: { output_tokens: response.usage.output_tokens }
+        };
+        yield { type: 'message_stop' };
+    }
+
+    return { checkGrokAvailable, sendGrokMessage, sendGrokMessageStream };
+}
+
+export const accountManager = new GrokAccountManager();
+const defaultBridge = createGrokBridge({ accountManager });
+export const checkGrokAvailable = defaultBridge.checkGrokAvailable;
+export const sendGrokMessage = defaultBridge.sendGrokMessage;
+export const sendGrokMessageStream = defaultBridge.sendGrokMessageStream;

--- a/src/cloudcode/index.js
+++ b/src/cloudcode/index.js
@@ -12,16 +12,27 @@
 // Re-export public API
 export { sendMessage } from './message-handler.js';
 export { sendMessageStream } from './streaming-handler.js';
+export {
+    sendGrokMessage,
+    sendGrokMessageStream,
+    checkGrokAvailable,
+    spawnGrokProcess,
+    accountManager as grokAccountManager
+} from './grok-bridge.js';
 export { listModels, fetchAvailableModels, getModelQuotas, getSubscriptionTier, isValidModel } from './model-api.js';
 
 // Default export for backwards compatibility
 import { sendMessage } from './message-handler.js';
 import { sendMessageStream } from './streaming-handler.js';
+import { sendGrokMessage, sendGrokMessageStream, checkGrokAvailable } from './grok-bridge.js';
 import { listModels, fetchAvailableModels, getModelQuotas, getSubscriptionTier, isValidModel } from './model-api.js';
 
 export default {
     sendMessage,
     sendMessageStream,
+    sendGrokMessage,
+    sendGrokMessageStream,
+    checkGrokAvailable,
     listModels,
     fetchAvailableModels,
     getModelQuotas,

--- a/src/cloudcode/model-api.js
+++ b/src/cloudcode/model-api.js
@@ -30,7 +30,7 @@ const modelCache = {
  */
 function isSupportedModel(modelId) {
     const family = getModelFamily(modelId);
-    return family === 'claude' || family === 'gemini';
+    return family === 'claude' || family === 'gemini' || family === 'gpt-oss';
 }
 
 /**

--- a/src/cloudcode/model-api.js
+++ b/src/cloudcode/model-api.js
@@ -30,7 +30,7 @@ const modelCache = {
  */
 function isSupportedModel(modelId) {
     const family = getModelFamily(modelId);
-    return family === 'claude' || family === 'gemini' || family === 'gpt-oss';
+    return family === 'claude' || family === 'gemini' || family === 'gpt-oss' || family === 'grok';
 }
 
 /**

--- a/src/constants.js
+++ b/src/constants.js
@@ -224,6 +224,7 @@ export function getModelFamily(modelName) {
     const lower = (modelName || '').toLowerCase();
     if (lower.includes('claude')) return 'claude';
     if (lower.includes('gemini')) return 'gemini';
+    if (lower.includes('gpt-oss')) return 'gpt-oss';
     return 'unknown';
 }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -225,6 +225,7 @@ export function getModelFamily(modelName) {
     if (lower.includes('claude')) return 'claude';
     if (lower.includes('gemini')) return 'gemini';
     if (lower.includes('gpt-oss')) return 'gpt-oss';
+    if (lower.startsWith('grok-')) return 'grok';
     return 'unknown';
 }
 

--- a/src/grok/grok-account-manager.js
+++ b/src/grok/grok-account-manager.js
@@ -1,0 +1,189 @@
+/**
+ * Manages isolated Grok CLI accounts and rotates between healthy accounts.
+ */
+import { existsSync, mkdirSync, readFileSync } from 'fs';
+import { writeFile } from 'fs/promises';
+import { homedir } from 'os';
+import { join } from 'path';
+import { logger } from '../utils/logger.js';
+
+const GROK_CONFIG_PATH = join(homedir(), '.antigravity-grok-accounts.json');
+const GROK_RATE_LIMIT_COOLDOWN = 120_000;
+const DEFAULT_MAX_CONSECUTIVE_FAILURES = 5;
+
+export class GrokAccountManager {
+    #accounts = [];
+    #strategy = 'round-robin';
+    #currentIndex = 0;
+    #initialized = false;
+
+    constructor() {
+        this.#loadConfigSync();
+    }
+
+    async initialize() {
+        if (this.#initialized) return;
+        this.#loadConfigSync();
+        this.#initialized = true;
+        logger.info(`[GrokAccountManager] Loaded ${this.#accounts.length} grok account(s)`);
+    }
+
+    #loadConfigSync() {
+        try {
+            if (!existsSync(GROK_CONFIG_PATH)) {
+                this.#accounts = [];
+                return;
+            }
+            let raw = readFileSync(GROK_CONFIG_PATH, 'utf-8');
+            if (raw.charCodeAt(0) === 0xFEFF) raw = raw.slice(1);
+            const data = JSON.parse(raw);
+            this.#accounts = (data.accounts || []).map(account => ({
+                ...account,
+                enabled: account.enabled !== false,
+                lastUsed: account.lastUsed || null,
+                failures: 0,
+                isRateLimited: false,
+                rateLimitResetAt: null,
+                error: null
+            }));
+            this.#strategy = data.strategy || 'round-robin';
+        } catch {
+            this.#accounts = [];
+        }
+    }
+
+    async #saveConfig() {
+        const data = {
+            strategy: this.#strategy,
+            accounts: this.#accounts.map(account => ({
+                alias: account.alias,
+                email: account.email,
+                dir: account.dir,
+                enabled: account.enabled,
+                lastUsed: account.lastUsed
+            }))
+        };
+        await writeFile(GROK_CONFIG_PATH, JSON.stringify(data, null, 2), 'utf-8');
+    }
+
+    #hasAuthFile(dir) {
+        const base = join(homedir(), dir);
+        return existsSync(join(base, '.grok', 'auth.json')) || existsSync(join(base, 'auth.json'));
+    }
+
+    getHomeDir(alias) {
+        const account = this.#accounts.find(candidate => candidate.alias === alias);
+        return account ? join(homedir(), account.dir) : null;
+    }
+
+    selectAccount() {
+        const available = this.#accounts.filter(account => {
+            if (!account.enabled) return false;
+            if (account.isRateLimited && account.rateLimitResetAt > Date.now()) return false;
+            if (account.failures >= DEFAULT_MAX_CONSECUTIVE_FAILURES) return false;
+            return this.#hasAuthFile(account.dir);
+        });
+        if (available.length === 0) return null;
+
+        if (this.#strategy === 'round-robin') {
+            const index = this.#currentIndex % available.length;
+            this.#currentIndex = (index + 1) % available.length;
+            return { ...available[index], homeDir: join(homedir(), available[index].dir) };
+        }
+
+        available.sort((a, b) => (a.lastUsed || 0) - (b.lastUsed || 0));
+        return { ...available[0], homeDir: join(homedir(), available[0].dir) };
+    }
+
+    markRateLimited(alias, reason) {
+        const account = this.#accounts.find(candidate => candidate.alias === alias);
+        if (!account) return;
+        account.isRateLimited = true;
+        account.rateLimitResetAt = Date.now() + GROK_RATE_LIMIT_COOLDOWN;
+        account.failures = (account.failures || 0) + 1;
+        account.error = reason;
+        account.lastUsed = Date.now();
+        logger.warn(`[GrokAccountManager] ${alias} rate-limited: ${reason}`);
+    }
+
+    markSuccess(alias) {
+        const account = this.#accounts.find(candidate => candidate.alias === alias);
+        if (!account) return;
+        account.failures = 0;
+        account.isRateLimited = false;
+        account.rateLimitResetAt = null;
+        account.error = null;
+        account.lastUsed = Date.now();
+    }
+
+    isAllRateLimited() {
+        if (this.#accounts.length === 0) return true;
+        return this.#accounts.every(account => account.isRateLimited && account.rateLimitResetAt > Date.now());
+    }
+
+    async addAccount(alias, email) {
+        if (this.#accounts.find(account => account.alias === alias)) {
+            throw new Error(`Grok account '${alias}' already exists`);
+        }
+        const dir = `.grok-${alias}`;
+        const homeDir = join(homedir(), dir);
+        mkdirSync(homeDir, { recursive: true });
+        this.#accounts.push({
+            alias,
+            email,
+            dir,
+            enabled: true,
+            lastUsed: null,
+            failures: 0,
+            isRateLimited: false,
+            rateLimitResetAt: null,
+            error: null
+        });
+        await this.#saveConfig();
+        logger.info(`[GrokAccountManager] Added account ${email} as '${alias}'`);
+        return { alias, email, dir, homeDir };
+    }
+
+    async removeAccount(alias) {
+        const index = this.#accounts.findIndex(account => account.alias === alias);
+        if (index === -1) throw new Error(`Grok account '${alias}' not found`);
+        this.#accounts.splice(index, 1);
+        await this.#saveConfig();
+    }
+
+    getAccount(alias) {
+        return this.getAccounts().find(account => account.alias === alias) || null;
+    }
+
+    getAccounts() {
+        return this.#accounts.map(account => ({
+            ...account,
+            homeDir: join(homedir(), account.dir),
+            hasAuth: this.#hasAuthFile(account.dir),
+            isCurrentlyRateLimited: account.isRateLimited && account.rateLimitResetAt > Date.now(),
+            rateLimitRemainingMs: account.isRateLimited
+                ? Math.max(0, account.rateLimitResetAt - Date.now())
+                : 0
+        }));
+    }
+
+    getStatus() {
+        const accounts = this.getAccounts();
+        return {
+            total: accounts.length,
+            available: accounts.filter(account => !account.isCurrentlyRateLimited && account.enabled && account.hasAuth).length,
+            rateLimited: accounts.filter(account => account.isCurrentlyRateLimited).length,
+            invalid: accounts.filter(account => !account.hasAuth).length,
+            disabled: accounts.filter(account => !account.enabled).length,
+            accounts
+        };
+    }
+
+    async toggleAccount(alias) {
+        const account = this.#accounts.find(candidate => candidate.alias === alias);
+        if (!account) throw new Error(`Grok account '${alias}' not found`);
+        account.enabled = !account.enabled;
+        await this.#saveConfig();
+        return account.enabled;
+    }
+}

--- a/src/grok/setup-grok-account.mjs
+++ b/src/grok/setup-grok-account.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/** Register an isolated Grok CLI account for the proxy. */
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { mkdir } from 'fs/promises';
+import { homedir } from 'os';
+import { join } from 'path';
+import { spawnSync } from 'child_process';
+
+const [alias, email] = process.argv.slice(2);
+if (!alias || !email) {
+    console.error('Usage: node setup-grok-account.mjs <alias> <email>');
+    process.exit(1);
+}
+
+const accountHome = join(homedir(), `.grok-${alias}`);
+const configPath = join(homedir(), '.antigravity-grok-accounts.json');
+const grokExecutable = join(homedir(), '.grok', 'bin', 'grok.exe');
+await mkdir(accountHome, { recursive: true });
+
+const authCandidates = [
+    join(accountHome, '.grok', 'auth.json'),
+    join(accountHome, 'auth.json')
+];
+if (!authCandidates.some(candidate => existsSync(candidate))) {
+    const result = spawnSync(grokExecutable, ['login'], {
+        env: { ...process.env, HOME: accountHome, USERPROFILE: accountHome },
+        stdio: 'inherit',
+        shell: false,
+        windowsHide: true
+    });
+    if (result.error) throw result.error;
+    if (result.status !== 0) process.exit(result.status || 1);
+}
+
+let config = { strategy: 'round-robin', accounts: [] };
+if (existsSync(configPath)) {
+    let raw = readFileSync(configPath, 'utf-8');
+    if (raw.charCodeAt(0) === 0xFEFF) raw = raw.slice(1);
+    config = JSON.parse(raw);
+}
+config.accounts ||= [];
+if (!config.accounts.some(account => account.alias === alias)) {
+    config.accounts.push({ alias, email, dir: `.grok-${alias}`, enabled: true, lastUsed: null });
+    writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
+}
+console.log(`Grok account '${alias}' is configured.`);

--- a/src/server.js
+++ b/src/server.js
@@ -956,6 +956,10 @@ app.post('/v1/messages', async (req, res) => {
         }
 
     } catch (error) {
+        if (req.aborted || res.destroyed || res.writableEnded || error.name === 'AbortError') {
+            logger.debug('[API] Request aborted by client; response channel is closed');
+            return;
+        }
         logger.error('[API] Error:', error);
 
         let { errorType, statusCode, errorMessage } = parseError(error);

--- a/src/server.js
+++ b/src/server.js
@@ -7,8 +7,22 @@
 import express from 'express';
 import cors from 'cors';
 import path from 'path';
+import os from 'os';
+import { existsSync } from 'fs';
 import { fileURLToPath } from 'url';
-import { sendMessage, sendMessageStream, listModels, getModelQuotas, getSubscriptionTier, isValidModel } from './cloudcode/index.js';
+import {
+    sendMessage,
+    sendMessageStream,
+    sendGrokMessage,
+    sendGrokMessageStream,
+    checkGrokAvailable,
+    spawnGrokProcess,
+    grokAccountManager,
+    listModels,
+    getModelQuotas,
+    getSubscriptionTier,
+    isValidModel
+} from './cloudcode/index.js';
 import { mountWebUI } from './webui/index.js';
 import { config } from './config.js';
 
@@ -37,6 +51,7 @@ for (let i = 0; i < args.length; i++) {
 }
 
 const app = express();
+const GROK_MODELS = ['grok-4.5', 'grok-4.5-build-free'];
 
 // Disable x-powered-by header for security
 app.disable('x-powered-by');
@@ -442,6 +457,11 @@ app.get('/account-limits', async (req, res) => {
 
         const sortedModels = Array.from(allModelIds).sort();
 
+        for (const model of GROK_MODELS) {
+            if (!sortedModels.includes(model)) sortedModels.push(model);
+        }
+        sortedModels.sort();
+
         // Return ASCII table format
         if (format === 'table') {
             res.setHeader('Content-Type', 'text/plain; charset=utf-8');
@@ -595,6 +615,13 @@ app.get('/account-limits', async (req, res) => {
                     // Quota limits
                     limits: Object.fromEntries(
                         sortedModels.map(modelId => {
+                            if (GROK_MODELS.includes(modelId)) {
+                                return [modelId, {
+                                    remaining: '100%',
+                                    remainingFraction: 1,
+                                    resetTime: null
+                                }];
+                            }
                             const quota = acc.models?.[modelId];
                             if (!quota) {
                                 return [modelId, null];
@@ -668,6 +695,20 @@ app.get('/v1/models', async (req, res) => {
         }
         const token = await accountManager.getTokenForAccount(account);
         const models = await listModels(token);
+        if (models?.data) {
+            const existingIds = new Set(models.data.map(model => model.id));
+            for (const model of GROK_MODELS) {
+                if (!existingIds.has(model)) {
+                    models.data.push({
+                        id: model,
+                        object: 'model',
+                        created: Math.floor(Date.now() / 1000),
+                        owned_by: 'xai',
+                        description: `xAI Grok ${model.replace('grok-', '')}`
+                    });
+                }
+            }
+        }
         res.json(models);
     } catch (error) {
         logger.error('[API] Error listing models:', error);
@@ -733,22 +774,25 @@ app.post('/v1/messages', async (req, res) => {
         }
 
         const modelId = requestedModel;
+        const isGrokModel = modelId.toLowerCase().startsWith('grok-');
 
-        // Validate model ID before processing
-        const { account: validationAccount } = accountManager.selectAccount();
-        if (validationAccount) {
-            const token = await accountManager.getTokenForAccount(validationAccount);
-            const projectId = validationAccount.subscription?.projectId || null;
-            const valid = await isValidModel(modelId, token, projectId);
+        // Grok models are provided by the local CLI bridge, not Cloud Code.
+        if (!isGrokModel) {
+            const { account: validationAccount } = accountManager.selectAccount();
+            if (validationAccount) {
+                const token = await accountManager.getTokenForAccount(validationAccount);
+                const projectId = validationAccount.subscription?.projectId || null;
+                const valid = await isValidModel(modelId, token, projectId);
 
-            if (!valid) {
-                throw new Error(`invalid_request_error: Invalid model: ${modelId}. Use /v1/models to see available models.`);
+                if (!valid) {
+                    throw new Error(`invalid_request_error: Invalid model: ${modelId}. Use /v1/models to see available models.`);
+                }
             }
         }
 
         // Optimistic Retry: If ALL accounts are rate-limited for this model, reset them to force a fresh check.
         // If we have some available accounts, we try them first.
-        if (accountManager.isAllRateLimited(modelId)) {
+        if (!isGrokModel && accountManager.isAllRateLimited(modelId)) {
             logger.warn(`[Server] All accounts rate-limited for ${modelId}. Resetting state for optimistic retry.`);
             accountManager.resetAllRateLimits();
         }
@@ -785,6 +829,51 @@ app.post('/v1/messages', async (req, res) => {
         };
 
         logger.info(`[API] Request for model: ${request.model}, stream: ${!!stream}`);
+
+        if (isGrokModel) {
+            const abortController = new AbortController();
+            const abortRequest = () => abortController.abort();
+            const abortOnResponseClose = () => {
+                if (!res.writableEnded) abortRequest();
+            };
+            req.once('aborted', abortRequest);
+            res.once('close', abortOnResponseClose);
+
+            try {
+                const grokAvailable = await checkGrokAvailable({ signal: abortController.signal });
+                if (!grokAvailable) {
+                    throw new Error('Grok CLI is not available or no authenticated Grok account is enabled');
+                }
+
+                if (stream) {
+                    const generator = sendGrokMessageStream(request, { signal: abortController.signal });
+                    const firstResult = await generator.next();
+                    res.status(200);
+                    res.setHeader('Content-Type', 'text/event-stream');
+                    res.setHeader('Cache-Control', 'no-cache');
+                    res.setHeader('Connection', 'keep-alive');
+                    res.flushHeaders();
+
+                    if (!firstResult.done) {
+                        res.write(`event: ${firstResult.value.type}\ndata: ${JSON.stringify(firstResult.value)}\n\n`);
+                        if (res.flush) res.flush();
+                    }
+                    for await (const event of generator) {
+                        res.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
+                        if (res.flush) res.flush();
+                    }
+                    res.end();
+                    return;
+                }
+
+                const response = await sendGrokMessage(request, { signal: abortController.signal });
+                res.json(response);
+                return;
+            } finally {
+                req.off('aborted', abortRequest);
+                res.off('close', abortOnResponseClose);
+            }
+        }
 
         // Debug: Log message structure to diagnose tool_use/tool_result ordering
         if (logger.isDebugEnabled) {
@@ -903,6 +992,134 @@ app.post('/v1/messages', async (req, res) => {
                 }
             });
         }
+    }
+});
+
+// ==========================================
+// Grok account management
+// ==========================================
+
+app.get('/api/grok/accounts', (req, res) => {
+    try {
+        res.json({ status: 'ok', ...grokAccountManager.getStatus() });
+    } catch (error) {
+        res.status(500).json({ status: 'error', error: error.message });
+    }
+});
+
+app.post('/api/grok/accounts', async (req, res) => {
+    try {
+        const { alias, email } = req.body;
+        if (!alias || !email) {
+            return res.status(400).json({ status: 'error', error: 'alias and email are required' });
+        }
+        const account = await grokAccountManager.addAccount(alias, email);
+        res.json({ status: 'ok', account });
+    } catch (error) {
+        res.status(400).json({ status: 'error', error: error.message });
+    }
+});
+
+app.post('/api/grok/accounts/:alias/login', async (req, res) => {
+    try {
+        const { alias } = req.params;
+        const account = grokAccountManager.getAccount(alias);
+        if (!account) {
+            return res.status(404).json({ status: 'error', error: `Account '${alias}' not found` });
+        }
+
+        const child = spawnGrokProcess(['login', '--device-auth', '--debug'], {
+            homeDir: account.homeDir,
+            stdio: ['ignore', 'pipe', 'pipe']
+        });
+
+        const deviceInfo = await new Promise((resolve, reject) => {
+            let output = '';
+            let settled = false;
+            const finish = (callback, value) => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timeout);
+                callback(value);
+            };
+            const inspectOutput = () => {
+                const urlMatch = output.match(/https:\/\/accounts\.x\.ai\/oauth2\/device\?user_code=([A-Z0-9-]+)/);
+                const codeMatch = output.match(/Confirm this code in your browser:\s*\n?\s*([A-Z0-9-]+)/);
+                if (urlMatch && codeMatch) {
+                    finish(resolve, { url: urlMatch[0], userCode: codeMatch[1] });
+                }
+            };
+            const appendOutput = data => {
+                output += data.toString();
+                inspectOutput();
+            };
+            const timeout = setTimeout(() => {
+                try { child.kill(); } catch { /* process already exited */ }
+                finish(reject, new Error('Device code login timed out'));
+            }, 15_000);
+
+            child.stdout.on('data', appendOutput);
+            child.stderr.on('data', appendOutput);
+            child.on('close', code => finish(resolve, {
+                url: null,
+                userCode: null,
+                exitCode: code,
+                output
+            }));
+            child.on('error', error => finish(reject, error));
+        });
+
+        if (deviceInfo.url && deviceInfo.userCode) {
+            res.json({
+                status: 'ok',
+                deviceUrl: deviceInfo.url,
+                userCode: deviceInfo.userCode,
+                message: 'Open the URL in your browser and confirm the code. The CLI is waiting in background.'
+            });
+        } else {
+            res.status(500).json({
+                status: 'error',
+                error: 'Failed to get a device code',
+                exitCode: deviceInfo.exitCode
+            });
+        }
+    } catch (error) {
+        res.status(500).json({ status: 'error', error: error.message });
+    }
+});
+
+app.post('/api/grok/accounts/:alias/login-check', (req, res) => {
+    try {
+        const { alias } = req.params;
+        const account = grokAccountManager.getAccount(alias);
+        if (!account) {
+            return res.status(404).json({ status: 'error', error: `Account '${alias}' not found` });
+        }
+        const hasAuth = [
+            path.join(account.homeDir, '.grok', 'auth.json'),
+            path.join(account.homeDir, 'auth.json')
+        ].some(candidate => existsSync(candidate));
+        res.json({ status: 'ok', alias, hasAuth });
+    } catch (error) {
+        res.status(500).json({ status: 'error', error: error.message });
+    }
+});
+
+app.delete('/api/grok/accounts/:alias', async (req, res) => {
+    try {
+        await grokAccountManager.removeAccount(req.params.alias);
+        res.json({ status: 'ok', message: `Grok account '${req.params.alias}' removed` });
+    } catch (error) {
+        res.status(400).json({ status: 'error', error: error.message });
+    }
+});
+
+app.post('/api/grok/accounts/:alias/toggle', async (req, res) => {
+    try {
+        const enabled = await grokAccountManager.toggleAccount(req.params.alias);
+        res.json({ status: 'ok', alias: req.params.alias, enabled });
+    } catch (error) {
+        res.status(400).json({ status: 'error', error: error.message });
     }
 });
 

--- a/tests/run-all.cjs
+++ b/tests/run-all.cjs
@@ -24,7 +24,8 @@ const tests = [
     { name: 'Streaming Whitespace', file: 'test-streaming-whitespace.cjs' },
     { name: '403 Account Rotation (Unit)', file: 'test-403-account-rotation.cjs' },
     { name: '403 Account Rotation (Integration)', file: 'test-403-integration.cjs' },
-    { name: 'Version Detection', file: 'test-version-detection.js' }
+    { name: 'Version Detection', file: 'test-version-detection.js' },
+    { name: 'Grok Bridge', file: 'test-grok-bridge.test.cjs' }
 ];
 
 async function runTest(test) {

--- a/tests/test-grok-bridge.test.cjs
+++ b/tests/test-grok-bridge.test.cjs
@@ -1,0 +1,185 @@
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const { PassThrough } = require('node:stream');
+const test = require('node:test');
+
+function createChild() {
+    const child = new EventEmitter();
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.killed = false;
+    child.unref = () => {};
+    child.kill = () => {
+        child.killed = true;
+        queueMicrotask(() => child.emit('close', null, 'SIGTERM'));
+        return true;
+    };
+    return child;
+}
+
+function createSpawnStub(plans) {
+    const calls = [];
+    const spawnImpl = (command, args, options) => {
+        const child = createChild();
+        calls.push({ command, args, options, child });
+        const plan = plans.shift();
+        if (plan) queueMicrotask(() => plan(child));
+        return child;
+    };
+    return { calls, spawnImpl };
+}
+
+function createAccountManager() {
+    const account = { alias: 'test', dir: '.grok-test', homeDir: 'C:\\test-grok-home' };
+    return {
+        initialize: async () => {},
+        selectAccount: () => account,
+        getAccounts: () => [account],
+        markSuccess: () => {},
+        markRateLimited: () => {},
+    };
+}
+
+async function loadBridge() {
+    return import('../src/cloudcode/grok-bridge.js');
+}
+
+test('health check hides the Windows subprocess and does not use a shell for grok.exe', async () => {
+    const { createGrokBridge } = await loadBridge();
+    const stub = createSpawnStub([child => child.emit('close', 0)]);
+    const bridge = createGrokBridge({
+        accountManager: createAccountManager(),
+        spawnImpl: stub.spawnImpl,
+        platform: 'win32',
+        grokCommand: { command: 'C:\\Users\\test\\.grok\\bin\\grok.exe', kind: 'executable' },
+    });
+
+    assert.equal(await bridge.checkGrokAvailable(), true);
+    assert.equal(stub.calls.length, 1);
+    assert.deepEqual(stub.calls[0].args, ['--version']);
+    assert.equal(stub.calls[0].options.windowsHide, true);
+    assert.equal(stub.calls[0].options.shell, false);
+    assert.deepEqual(stub.calls[0].options.stdio, ['ignore', 'ignore', 'ignore']);
+});
+
+test('request buffers JSON output, keeps the process hidden, and preserves response conversion', async () => {
+    const { createGrokBridge } = await loadBridge();
+    const stub = createSpawnStub([child => {
+        child.stdout.write('{"text":"hello",');
+        child.stdout.write('"stopReason":"EndTurn","usage":{"input_tokens":2,"output_tokens":1}}');
+        child.stdout.end();
+        child.emit('close', 0);
+    }]);
+    const bridge = createGrokBridge({
+        accountManager: createAccountManager(),
+        spawnImpl: stub.spawnImpl,
+        platform: 'win32',
+        grokCommand: { command: 'C:\\Users\\test\\.grok\\bin\\grok.exe', kind: 'executable' },
+    });
+
+    const response = await bridge.sendGrokMessage({
+        model: 'grok-4.5',
+        messages: [{ role: 'user', content: 'hello' }],
+    });
+
+    assert.equal(response.content[0].text, 'hello');
+    assert.equal(response.stop_reason, 'end_turn');
+    assert.deepEqual(response.usage, { input_tokens: 2, output_tokens: 1 });
+    assert.equal(stub.calls[0].options.windowsHide, true);
+    assert.equal(stub.calls[0].options.shell, false);
+    assert.deepEqual(stub.calls[0].options.stdio, ['ignore', 'pipe', 'pipe']);
+});
+
+test('buffered streaming emits a complete Anthropic SSE event sequence', async () => {
+    const { createGrokBridge } = await loadBridge();
+    const stub = createSpawnStub([child => {
+        child.stdout.end('{"text":"streamed","stopReason":"EndTurn","usage":{"input_tokens":3,"output_tokens":1}}');
+        child.emit('close', 0);
+    }]);
+    const bridge = createGrokBridge({
+        accountManager: createAccountManager(),
+        spawnImpl: stub.spawnImpl,
+        platform: 'win32',
+        grokCommand: { command: 'C:\\grok.exe', kind: 'executable' },
+    });
+
+    const events = [];
+    for await (const event of bridge.sendGrokMessageStream({ model: 'grok-4.5', messages: [] })) {
+        events.push(event);
+    }
+
+    assert.deepEqual(events.map(event => event.type), [
+        'message_start',
+        'content_block_start',
+        'content_block_delta',
+        'content_block_stop',
+        'message_delta',
+        'message_stop',
+    ]);
+    assert.equal(events[2].delta.text, 'streamed');
+});
+
+test('timeout kills the child and rejects with a timeout error', async () => {
+    const { createGrokBridge } = await loadBridge();
+    const stub = createSpawnStub([]);
+    const bridge = createGrokBridge({
+        accountManager: createAccountManager(),
+        spawnImpl: stub.spawnImpl,
+        grokCommand: { command: 'grok', kind: 'executable' },
+        requestTimeoutMs: 10,
+    });
+
+    await assert.rejects(
+        bridge.sendGrokMessage({ model: 'grok-4.5', messages: [] }),
+        /timed out/i,
+    );
+    assert.equal(stub.calls[0].child.killed, true);
+});
+
+test('AbortSignal kills the child and propagates an abort error', async () => {
+    const { createGrokBridge } = await loadBridge();
+    const stub = createSpawnStub([]);
+    const bridge = createGrokBridge({
+        accountManager: createAccountManager(),
+        spawnImpl: stub.spawnImpl,
+        grokCommand: { command: 'grok', kind: 'executable' },
+    });
+    const controller = new AbortController();
+    const pending = bridge.sendGrokMessage({ model: 'grok-4.5', messages: [] }, { signal: controller.signal });
+    await new Promise(resolve => setImmediate(resolve));
+    controller.abort();
+
+    await assert.rejects(pending, /aborted/i);
+    assert.equal(stub.calls[0].child.killed, true);
+});
+
+test('spawn errors propagate without leaking a child process', async () => {
+    const { createGrokBridge } = await loadBridge();
+    const stub = createSpawnStub([child => child.emit('error', new Error('ENOENT'))]);
+    const bridge = createGrokBridge({
+        accountManager: createAccountManager(),
+        spawnImpl: stub.spawnImpl,
+        grokCommand: { command: 'grok', kind: 'executable' },
+    });
+
+    await assert.rejects(
+        bridge.sendGrokMessage({ model: 'grok-4.5', messages: [] }),
+        /Grok CLI unavailable: ENOENT/,
+    );
+});
+
+test('grok.cmd fallback uses hidden cmd.exe with shell disabled and quoted arguments', async () => {
+    const { buildGrokLaunch } = await loadBridge();
+    const launch = buildGrokLaunch(
+        { command: 'C:\\Program Files\\Grok\\grok.cmd', kind: 'cmd' },
+        ['--prompt-file', 'C:\\Temp Folder\\prompt.txt'],
+        { platform: 'win32', comSpec: 'C:\\Windows\\System32\\cmd.exe' },
+    );
+
+    assert.equal(launch.command, 'C:\\Windows\\System32\\cmd.exe');
+    assert.deepEqual(launch.args.slice(0, 3), ['/d', '/s', '/c']);
+    assert.match(launch.args[3], /"C:\\Program Files\\Grok\\grok\.cmd"/);
+    assert.match(launch.args[3], /"C:\\Temp Folder\\prompt\.txt"/);
+    assert.equal(launch.options.windowsHide, true);
+    assert.equal(launch.options.shell, false);
+});

--- a/tests/test-grok-bridge.test.cjs
+++ b/tests/test-grok-bridge.test.cjs
@@ -182,4 +182,27 @@ test('grok.cmd fallback uses hidden cmd.exe with shell disabled and quoted argum
     assert.match(launch.args[3], /"C:\\Temp Folder\\prompt\.txt"/);
     assert.equal(launch.options.windowsHide, true);
     assert.equal(launch.options.shell, false);
+    assert.equal(launch.options.windowsVerbatimArguments, true);
+});
+
+test('Windows cancellation terminates the entire subprocess tree without a shell', async () => {
+    const { terminateGrokProcess } = await loadBridge();
+    const child = createChild();
+    child.pid = 4321;
+    let call;
+    const confirmed = terminateGrokProcess(child, {
+        platform: 'win32',
+        systemRoot: 'C:\\Windows',
+        spawnSyncImpl: (command, args, options) => {
+            call = { command, args, options };
+            return { status: 0 };
+        },
+    });
+
+    assert.equal(confirmed, true);
+    assert.equal(call.command, 'C:\\Windows\\System32\\taskkill.exe');
+    assert.deepEqual(call.args, ['/pid', '4321', '/t', '/f']);
+    assert.equal(call.options.windowsHide, true);
+    assert.equal(call.options.shell, false);
+    assert.equal(child.killed, false);
 });


### PR DESCRIPTION
## Summary

Adds support for GPT-OSS models (e.g. `gpt-oss-120b-medium`) served via the Antigravity Cloud Code API.

Previously, only Claude and Gemini families were recognized — any other model family was silently filtered out as `'unknown'` and hidden from the WebUI. This patch adds `'gpt-oss'` as a third recognized family.

## Changes

- **src/constants.js** — `getModelFamily()` returns `'gpt-oss'` when model ID contains `gpt-oss`
- **src/cloudcode/model-api.js** — `isSupportedModel()` accepts `gpt-oss` family (enables `/v1/models` listing + quota tracking)
- **public/js/data-store.js** — Frontend `getModelFamily()` recognizes `gpt-oss` (no longer defaults to `'other'` which means hidden)
- **public/views/models.html** — Added **GPT** filter button alongside ALL / CLAUDE / GEMINI (neon-cyan styling)
- **public/js/components/model-dropdown.js** — Added `GPT-OSS` group in model selector dropdown

## Motivation

Google has begun serving GPT-OSS models (OpenAI open-source) through the Antigravity Cloud Code API alongside Claude and Gemini. Users with Antigravity accounts can now access `gpt-oss-120b-medium` and similar models, but the proxy rejects them with "Invalid model" because the family filter only recognizes `claude` and `gemini`.

## Testing

- Verified `gpt-oss-120b-medium` appears in `GET /v1/models` response
- Verified successful API call: `POST /v1/messages` with `model: gpt-oss-120b-medium` returns 200 OK
- Verified WebUI Models page shows GPT filter button and GPT-OSS quota rows per account
