### PR TITLE
fix: include tool call id for non-Claude, non-Gemini models

### DIFF
--- a/src/format/content-converter.js
+++ b/src/format/content-converter.js
@@ -89,7 +89,8 @@ export function convertContentToParts(content, isClaudeModel = false, isGeminiMo
                 args: block.input || {}
             };
 
-            if (isClaudeModel && block.id) {
+            // Include id for all models except Gemini (Gemini uses thoughtSignature instead)
+            if (!isGeminiModel && block.id) {
                 functionCall.id = block.id;
             }
 
@@ -146,8 +147,8 @@ export function convertContentToParts(content, isClaudeModel = false, isGeminiMo
                 response: responseContent
             };
 
-            // For Claude models, the id field must match the tool_use_id
-            if (isClaudeModel && block.tool_use_id) {
+            // Include id for all models except Gemini (Gemini uses thoughtSignature instead)
+            if (!isGeminiModel && block.tool_use_id) {
                 functionResponse.id = block.tool_use_id;
             }
 


### PR DESCRIPTION
## Summary

`functionCall.id` and `functionResponse.id` must be populated for all models when using Google Cloud Code API, except for Gemini models which use `thoughtSignature` instead. The current `isClaudeModel` guard only sets these fields for Claude models, breaking tool calls for any other model family.

## Changes

Changed the guard from `isClaudeModel` to `!isGeminiModel` in `src/format/content-converter.js`:

- `tool_use → functionCall`: `isClaudeModel && block.id` → `!isGeminiModel && block.id`
- `tool_result → functionResponse`: `isClaudeModel && block.tool_use_id` → `!isGeminiModel && block.tool_use_id`

## Why this matters

With PR #354 adding the `gpt-oss` model family, users will encounter tool call failures:
```
Expected the 'id' of a(n) 'assistant' 'tool_calls' array element to be populated.
```

This fix ensures any non-Gemini model family works correctly with tool calls, not just Claude.

## Compatibility

| Model | Before | After |
|-------|--------|-------|
| Claude | Gets `id` ✅ | Gets `id` ✅ (unchanged) |
| Gemini | No `id` ✅ (uses thoughtSignature) | No `id` ✅ (unchanged) |
| gpt-oss (or any future family) | No `id` ❌ (broken tool calls) | Gets `id` ✅ (fixed) |

## Related

- PR #354: GPT-OSS model family support
- Tested with `gpt-oss-120b-medium` and `gemini-3-flash`
