### PR TITLE
feat: recognize gpt-oss family in getModelFamily / isSupportedModel

### DIFF
--- a/src/cloudcode/model-api.js
+++ b/src/cloudcode/model-api.js
@@ -30,7 +30,7 @@ const modelCache = {
  */
 function isSupportedModel(modelId) {
     const family = getModelFamily(modelId);
-    return family === 'claude' || family === 'gemini';
+    return family === 'claude' || family === 'gemini' || family === 'gpt-oss';
 }
 
 /**

--- a/src/constants.js
+++ b/src/constants.js
@@ -224,6 +224,7 @@ export function getModelFamily(modelName) {
     const lower = (modelName || '').toLowerCase();
     if (lower.includes('claude')) return 'claude';
     if (lower.includes('gemini')) return 'gemini';
+    if (lower.includes('gpt-oss')) return 'gpt-oss';
     return 'unknown';
 }
 


### PR DESCRIPTION
The Antigravity desktop app now exposes OpenAI's open-weight `GPT-OSS 120B (Medium)` model alongside the Claude and Gemini tiers. The proxy currently rejects these names in `isValidModel()` because `getModelFamily()` only recognises the `claude` / `gemini` substrings, so any `crouter antigravity-claude --model gpt-oss-120b-medium` (or direct API call to `/v1/messages`) returns `invalid_request_error: Invalid model: gpt-oss-120b-medium`.

This adds a third family branch for any name containing `gpt-oss` and extends `isSupportedModel()` accordingly. Request/response conversion falls through the family-agnostic path, which uses the same Google Generative-AI envelope the Gemini path uses upstream.

Patch scope is intentionally minimal — no `MODEL_FALLBACK_MAP` entries (need observed quota behavior first) and no converter changes (need observed tool-use / thinking behavior first). Happy to follow up with either once the validation change is in production.

Companion: [Luckycat133/crouter `b80e16c`](https://github.com/Luckycat133/crouter/commit/b80e16c) ships a local sed-based patcher (`bin/antigravity-proxy-patch`) that applies the same change idempotently on a local proxy checkout, so crouter users can use GPT-OSS today without waiting for the upstream merge.