### PR TITLE
fix: guarantee valid ARRAY.items in schema-sanitizer (#368)

### DIFF
--- a/src/format/schema-sanitizer.js
+++ b/src/format/schema-sanitizer.js
@@ -669,5 +669,42 @@ export function cleanSchema(schema) {
         result.type = toGoogleType(result.type);
     }
 
+    // Phase 6: Google's protobuf-based schema requires every ARRAY type to
+    // declare a single object `items` schema. Plain JSON Schema allows this
+    // to be omitted (`{ type: 'array' }` = "array of anything"), boolean
+    // (`items: true` = "any"), or tuple-form (`items: [...]`) - none of
+    // which the Cloud Code API accepts; it rejects the first two with
+    // "items: missing field". This runs after the items/properties
+    // recursion above (and after Phase 5's type conversion), so it applies
+    // at every nesting depth - fixing issue #368 (nested array schemas like
+    // `where.items.items` losing their innermost `items`).
+    if (result.type === 'ARRAY') {
+        if (!result.items || typeof result.items !== 'object') {
+            // Missing entirely, or a boolean schema like `items: true`.
+            result.items = { type: 'STRING' };
+        } else if (Array.isArray(result.items)) {
+            // Tuple-form `items: [...]` - Google only supports one items
+            // schema, so collapse to the most informative entry.
+            let best = null;
+            let bestScore = -1;
+            for (const option of result.items) {
+                const score = scoreSchemaOption(option);
+                if (score > bestScore) {
+                    bestScore = score;
+                    best = option;
+                }
+            }
+            result.items = best || { type: 'STRING' };
+        }
+    }
+
+    // Phase 7: Google rejects `properties`/`required` on a non-OBJECT schema.
+    // These can survive on the current node after anyOf/oneOf flattening
+    // picked a non-object option while the parent still carried them.
+    if (result.type !== 'OBJECT') {
+        delete result.properties;
+        delete result.required;
+    }
+
     return result;
 }

--- a/tests/test-schema-sanitizer.cjs
+++ b/tests/test-schema-sanitizer.cjs
@@ -254,6 +254,110 @@ async function runTests() {
         assertEqual(result.properties.todoList.items.properties.status.type, 'STRING');
     });
 
+    // Structural invariant: every schema node produced by cleanSchema must be
+    // valid for Google's protobuf-based Schema format - specifically, every
+    // ARRAY must carry exactly one object `items` schema, every type must be
+    // one of Google's uppercase names, and only OBJECT nodes may carry
+    // `properties`/`required`. Used by the tests below instead of asserting
+    // one invented shape, so it catches any cause that produces the same
+    // class of invalid payload (not just the literal repro schema).
+    function assertGoogleSchemaValid(node, path = '$') {
+        if (!node || typeof node !== 'object') return;
+        if (node.type === 'ARRAY' && (!node.items || typeof node.items !== 'object' || Array.isArray(node.items))) {
+            throw new Error(`${path}: ARRAY without a single object items (got ${JSON.stringify(node.items)})`);
+        }
+        if (node.type && !['STRING', 'NUMBER', 'INTEGER', 'BOOLEAN', 'ARRAY', 'OBJECT'].includes(node.type)) {
+            throw new Error(`${path}: non-Google type ${node.type}`);
+        }
+        if (node.type !== 'OBJECT' && (node.properties || node.required)) {
+            throw new Error(`${path}: non-OBJECT node carries properties/required`);
+        }
+        if (node.items) assertGoogleSchemaValid(node.items, `${path}.items`);
+        for (const [k, v] of Object.entries(node.properties || {})) {
+            assertGoogleSchemaValid(v, `${path}.properties[${k}]`);
+        }
+    }
+
+    // Test 11: Array missing `items` gets a fallback (issue #368)
+    test('Bare array type without items gets a fallback items schema', () => {
+        const schema = { type: 'array' };
+        const result = cleanSchema(sanitizeSchema(schema));
+
+        assertEqual(result.type, 'ARRAY', 'Type should be ARRAY');
+        assertEqual(result.items, { type: 'STRING' }, 'Missing items should fall back to STRING');
+    });
+
+    // Test 12: Nested array-of-array where the innermost items is omitted (issue #368)
+    // Reproduces "properties[where].items.items: missing field" from the Google API.
+    test('Nested array-of-array with missing innermost items (issue #368)', () => {
+        const schema = {
+            type: 'object',
+            properties: {
+                query: {
+                    type: 'object',
+                    properties: {
+                        where: {
+                            type: 'array',
+                            items: { type: 'array' } // innermost items intentionally omitted
+                        }
+                    }
+                }
+            }
+        };
+        const result = cleanSchema(sanitizeSchema(schema));
+
+        const where = result.properties.query.properties.where;
+        assertEqual(where.type, 'ARRAY', 'where should be ARRAY');
+        assertEqual(where.items.type, 'ARRAY', 'where.items should be ARRAY');
+        assertEqual(where.items.items, { type: 'STRING' }, 'where.items.items should fall back to STRING, not be missing');
+        assertGoogleSchemaValid(result);
+    });
+
+    // Test 13: `items: true` (boolean/"any" schema) is normalized to an object (issue #368)
+    test('Boolean items schema is normalized to an object', () => {
+        const schema = { type: 'array', items: true };
+        const result = cleanSchema(schema); // bypass sanitizeSchema's allowlist to hit cleanSchema directly
+        assertEqual(result.type, 'ARRAY');
+        assertEqual(typeof result.items, 'object', 'items should be normalized to an object, not left as boolean');
+        assertGoogleSchemaValid(result);
+    });
+
+    // Test 14: Tuple-form `items: [...]` is collapsed to a single schema (issue #368)
+    test('Tuple-form items array is collapsed to one representative schema', () => {
+        const schema = {
+            type: 'array',
+            items: [{ type: 'string' }, { type: 'object', properties: { x: { type: 'string' } } }]
+        };
+        const result = cleanSchema(schema);
+        assertEqual(result.type, 'ARRAY');
+        assertEqual(Array.isArray(result.items), false, 'items should be collapsed to a single schema, not an array');
+        assertGoogleSchemaValid(result);
+    });
+
+    // Test 15: Full suite of prior schemas still satisfies the structural invariant
+    test('All prior real-world schemas satisfy the Google schema invariant', () => {
+        const schema = {
+            type: 'object',
+            properties: {
+                operation: { type: 'string', enum: ['write', 'read'] },
+                todoList: {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        properties: {
+                            id: { type: 'number' },
+                            title: { type: 'string' },
+                            status: { type: 'string', enum: ['not-started', 'in-progress', 'completed'] }
+                        },
+                        required: ['id', 'title', 'status']
+                    }
+                }
+            },
+            required: ['operation']
+        };
+        assertGoogleSchemaValid(cleanSchema(sanitizeSchema(schema)));
+    });
+
     // Summary
     console.log('\n' + '═'.repeat(60));
     console.log(`Tests completed: ${passed} passed, ${failed} failed`);


### PR DESCRIPTION
Fixes #368

## Root cause

Google's protobuf-based `Schema` format requires every `ARRAY` type to carry a single object `items` schema. Plain JSON Schema allows this to be omitted (`{ type: 'array' }` = "array of anything"), boolean (`items: true`), or tuple-form (`items: [...]`) — none of which the Cloud Code API accepts. It rejects the first two with `items: missing field`, which is exactly what #368 reports for a nested array parameter like `where: array<array<...>>` — the innermost `items` was never present in the source tool schema to begin with.

`cleanSchema()` already recurses into `items` before doing its own type conversion at each level, so I added the fix as the **last step of the function**, after Phase 5's type conversion. That makes it a terminal invariant ("every `ARRAY` node this function returns has valid `items`") that fires at *every* nesting depth automatically — rather than a shape-specific patch tied to the exact schema in the bug report. It also handles boolean and tuple-form `items`, and strips stray `properties`/`required` that can survive on a non-`OBJECT` node after `anyOf`/`oneOf` flattening (Google rejects those too).

## Verification

- Added 5 new tests to `tests/test-schema-sanitizer.cjs` (15/15 passing), including a structural invariant walker (`assertGoogleSchemaValid`) that checks the *class* of bug rather than one specific schema shape.
- Reproduced the issue end-to-end against the real Cloud Code API: sent the exact repro shape (a tool with a `where: array<array<...>>` parameter) to a locally running proxy.
  - **Before the fix**: got the identical error from the issue: `properties[query].properties[where].items.items: missing field`.
  - **After the fix**: clean `tool_use` response with the nested array argument (`{"where":[["status","=","open"]]}"`) parsed correctly, `stop_reason: "end_turn"`.
- Ran the full test suite (`node tests/run-all.cjs`) — no regressions in any other suite. (A handful of live-model behavioral tests around tool-call timing are flaky independent of this change — confirmed identical failures on `main` without this patch.)

## Note on the fallback value

The fallback for a missing/invalid items schema is `{ type: 'STRING' }`, matching what other community-reported patches on the issue converged on. This means a JSON Schema that genuinely meant "array of anything" gets typed as "array of strings" for Gemini's benefit — worth knowing, but it trades an unconditional 400 for, at worst, an occasional malformed tool argument, which is a clear improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Avy8HuPokCHP1MQvZVUVQt