### PR TITLE
chore: curate /v1/models listing, drop stale doc/test refs

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -3,17 +3,19 @@
 ## Claude Models
 
 | Model ID                     | Description                              |
-| ---------------------------- | ---------------------------------------- |
-| `claude-sonnet-4-6-thinking` | Claude Sonnet 4.6 with extended thinking |
-| `claude-opus-4-6-thinking`   | Claude Opus 4.6 with extended thinking   |
-| `claude-sonnet-4-6`          | Claude Sonnet 4.6 without thinking       |
+| ----------------------------- | ---------------------------------------- |
+| `claude-sonnet-4-6-thinking`  | Claude Sonnet 4.6 with extended thinking |
+| `claude-opus-4-6-thinking`    | Claude Opus 4.6 with extended thinking   |
+| `claude-sonnet-4-6`           | Claude Sonnet 4.6 without thinking       |
 
 ## Gemini Models
 
-| Model ID            | Description                     |
-| ------------------- | ------------------------------- |
-| `gemini-3-flash`    | Gemini 3 Flash with thinking    |
-| `gemini-3.1-pro-low`  | Gemini 3.1 Pro Low with thinking  |
-| `gemini-3.1-pro-high` | Gemini 3.1 Pro High with thinking |
+```bash
+curl http://localhost:8080/v1/models
+```
+
+`/v1/models` hides Gemini generations below 3.5 (`2.5-*`, `3-flash`, `3.1-*`) and the
+unversioned duplicate aliases `gemini-pro-agent` / `gemini-3-flash-agent`. Hidden ids
+still work if configured explicitly (e.g. `ANTHROPIC_MODEL=gemini-3.1-pro-low`).
 
 Gemini models include full thinking support with `thoughtSignature` handling for multi-turn conversations.

--- a/docs/openclaw.md
+++ b/docs/openclaw.md
@@ -27,8 +27,8 @@ Add the following configuration:
         "api": "anthropic-messages",
         "models": [
           {
-            "id": "gemini-3-flash",
-            "name": "Gemini 3 Flash",
+            "id": "gemini-3.8-flash-tiered",
+            "name": "Gemini 3.8 Flash",
             "reasoning": true,
             "input": ["text", "image"],
             "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
@@ -36,8 +36,8 @@ Add the following configuration:
             "maxTokens": 65536
           },
           {
-            "id": "gemini-3.1-pro-high",
-            "name": "Gemini 3.1 Pro High",
+            "id": "gemini-3.6-flash-high",
+            "name": "Gemini 3.6 Flash (High)",
             "reasoning": true,
             "input": ["text", "image"],
             "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
@@ -78,11 +78,11 @@ Add the following configuration:
   "agents": {
     "defaults": {
       "model": {
-        "primary": "antigravity-proxy/gemini-3-flash",
-        "fallbacks": ["antigravity-proxy/gemini-3.1-pro-high"]
+        "primary": "antigravity-proxy/gemini-3.8-flash-tiered",
+        "fallbacks": ["antigravity-proxy/gemini-3.6-flash-high"]
       },
       "models": {
-        "antigravity-proxy/gemini-3-flash": {}
+        "antigravity-proxy/gemini-3.8-flash-tiered": {}
       }
     }
   }

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -44,16 +44,8 @@ cat > ~/.config/opencode/opencode.json <<'EOF'
       "models": {
         "claude-sonnet-4-6": { "id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6" },
         "claude-opus-4-6-thinking": { "id": "claude-opus-4-6-thinking", "name": "Claude Opus 4.6 Thinking" },
-        "gemini-2.5-pro": { "id": "gemini-2.5-pro", "name": "Gemini 2.5 Pro" },
-        "gemini-2.5-flash": { "id": "gemini-2.5-flash", "name": "Gemini 2.5 Flash" },
-        "gemini-2.5-flash-lite": { "id": "gemini-2.5-flash-lite", "name": "Gemini 2.5 Flash Lite" },
-        "gemini-2.5-flash-thinking": { "id": "gemini-2.5-flash-thinking", "name": "Gemini 2.5 Flash Thinking" },
-        "gemini-3-flash": { "id": "gemini-3-flash", "name": "Gemini 3 Flash" },
-        "gemini-3-flash-agent": { "id": "gemini-3-flash-agent", "name": "Gemini 3 Flash Agent" },
-        "gemini-pro-agent": { "id": "gemini-pro-agent", "name": "Gemini 3.1 Pro Agent" },
-        "gemini-3.1-pro-low": { "id": "gemini-3.1-pro-low", "name": "Gemini 3.1 Pro Low" },
-        "gemini-3.1-flash-lite": { "id": "gemini-3.1-flash-lite", "name": "Gemini 3.1 Flash Lite" },
-        "gemini-3.1-flash-image": { "id": "gemini-3.1-flash-image", "name": "Gemini 3.1 Flash Image" },
+        "gemini-3.8-flash-tiered": { "id": "gemini-3.8-flash-tiered", "name": "Gemini 3.8 Flash" },
+        "gemini-3.6-flash-high": { "id": "gemini-3.6-flash-high", "name": "Gemini 3.6 Flash (High)" },
         "gemini-3.5-flash-low": { "id": "gemini-3.5-flash-low", "name": "Gemini 3.5 Flash" }
       }
     }
@@ -96,16 +88,8 @@ Inside OpenCode, all registered models appear as `antigravity/<model-id>`. The `
 |---|---|---|
 | `claude-sonnet-4-6` | Claude | Coding, refactoring |
 | `claude-opus-4-6-thinking` | Claude | Architecture, deep reasoning |
-| `gemini-2.5-pro` | Gemini | Long context, analysis |
-| `gemini-2.5-flash` | Gemini | Fast general tasks |
-| `gemini-2.5-flash-lite` | Gemini | Background tasks |
-| `gemini-2.5-flash-thinking` | Gemini | Reasoning tasks |
-| `gemini-3-flash` | Gemini | Fast, lightweight |
-| `gemini-3-flash-agent` | Gemini | Agentic workflows |
-| `gemini-pro-agent` | Gemini | Agentic workflows |
-| `gemini-3.1-pro-low` | Gemini | Strong reasoning, 1M context |
-| `gemini-3.1-flash-lite` | Gemini | Lightweight tasks |
-| `gemini-3.1-flash-image` | Gemini | Vision/image tasks |
+| `gemini-3.8-flash-tiered` | Gemini | Latest Flash tier, fast general tasks |
+| `gemini-3.6-flash-high` | Gemini | Stronger reasoning, agentic workflows |
 | `gemini-3.5-flash-low` | Gemini | Fast tasks, `small_model` recommended |
 
 ## Verify Configuration

--- a/public/js/data-store.js
+++ b/public/js/data-store.js
@@ -437,10 +437,10 @@ document.addEventListener('alpine:init', () => {
             const models = [
                 'claude-opus-4-6-thinking',
                 'claude-sonnet-4-6',
-                'gemini-3.1-pro-high',
-                'gemini-3.1-pro-low',
-                'gemini-3-flash',
-                'gemini-3.1-flash-lite'
+                'gemini-3.8-flash-tiered',
+                'gemini-3.6-flash-high',
+                'gemini-3.6-flash-low',
+                'gemini-3.5-flash-low'
             ];
 
             const tiers = ['ultra', 'pro', 'pro', 'free'];

--- a/src/cloudcode/model-api.js
+++ b/src/cloudcode/model-api.js
@@ -34,6 +34,23 @@ function isSupportedModel(modelId) {
 }
 
 /**
+ * Whether a model id is an old Gemini generation (version below 3.5),
+ * hidden from the /v1/models listing in favor of the current line. Claude
+ * ids aren't versioned this way and are unaffected.
+ * @param {string} modelId
+ * @returns {boolean}
+ */
+function isOldGemini(modelId) {
+    // 'gemini-pro-agent' carries no version number in its id at all - it's
+    // an unversioned duplicate alias of gemini-3.1-pro-high, so it's always
+    // old regardless of what the version regex below would say.
+    if (modelId === 'gemini-pro-agent') return true;
+
+    const match = modelId.match(/^gemini-(\d+(?:\.\d+)?)/);
+    return !!match && parseFloat(match[1]) < 3.5;
+}
+
+/**
  * List available models in Anthropic API format
  * Fetches models dynamically from the Cloud Code API
  *
@@ -46,8 +63,17 @@ export async function listModels(token) {
         return { object: 'list', data: [] };
     }
 
-    const modelList = Object.entries(data.models)
-        .filter(([modelId]) => isSupportedModel(modelId))
+    const supportedEntries = Object.entries(data.models).filter(([modelId]) => isSupportedModel(modelId));
+
+    // Warm the model validation cache with every supported id, unfiltered -
+    // isValidModel() (the actual request-time gate) must keep accepting an
+    // id a client already has configured even if it's hidden from the
+    // listing below.
+    modelCache.validModels = new Set(supportedEntries.map(([modelId]) => modelId));
+    modelCache.lastFetched = Date.now();
+
+    const modelList = supportedEntries
+        .filter(([modelId]) => !isOldGemini(modelId))
         .map(([modelId, modelData]) => ({
             id: modelId,
             object: 'model',
@@ -55,10 +81,6 @@ export async function listModels(token) {
             owned_by: 'anthropic',
             description: modelData.displayName || modelId
         }));
-
-    // Warm the model validation cache
-    modelCache.validModels = new Set(modelList.map(m => m.id));
-    modelCache.lastFetched = Date.now();
 
     return {
         object: 'list',

--- a/src/constants.js
+++ b/src/constants.js
@@ -287,7 +287,7 @@ export const MODEL_FALLBACK_MAP = {
 // Default test models for each family (used by test suite)
 export const TEST_MODELS = {
     claude: 'claude-sonnet-4-6',
-    gemini: 'gemini-3.5-flash-low'
+    gemini: 'gemini-3.8-flash-tiered'
 };
 
 // Default Claude CLI presets (used by WebUI settings)


### PR DESCRIPTION
## What

`/v1/models` was a raw passthrough of whatever Google's Cloud Code API returns — 22 entries including the superseded `gemini-2.5-*` family and two unversioned duplicate aliases (`gemini-pro-agent`, `gemini-3-flash-agent`) with mismatched descriptions. This filters the listing to Gemini generations >= 3.5, down to 11 entries.

Display-only: the shared model-validation cache (used by real `/v1/messages` requests) is warmed from the full supported set, not the filtered list, so a hidden id (e.g. `gemini-3.1-pro-low`) still works if a client configures it directly — verified live (before/after: `curl /v1/models`, then a `/v1/messages` call using a hidden id still gets a real response, not the "Invalid model" rejection).

Also bumped `TEST_MODELS.gemini` (single source of truth for the test suite) to the latest tier, and swapped stale model-id references in `docs/models.md`, `docs/opencode.md`, `docs/openclaw.md`, and the WebUI's placeholder-data generator.

## Verification

- `node tests/test-schema-sanitizer.cjs` and full `node tests/run-all.cjs` pass, running against the bumped `gemini-3.8-flash-tiered` test model.
- Live-checked against the real Cloud Code API: `/v1/models` count 22 → 11; a hidden-but-configured model still completes requests normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Avy8HuPokCHP1MQvZVUVQt